### PR TITLE
0.2 dyn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,19 +37,12 @@ version = "0.1.2"
 dependencies = [
  "base64",
  "convert_case",
- "lazy_static",
  "proc-macro2",
  "quote",
  "speedy",
  "syn",
  "xxhash-rust",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memoffset"
@@ -68,18 +61,18 @@ checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -107,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,6 @@ proc-macro = true
 
 [dependencies]
 convert_case = { version = "0.6" }
-lazy_static = { version = "1.4" }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }
 syn = { version = "2.0", features = ["full", "extra-traits"] }

--- a/macros/src/data.rs
+++ b/macros/src/data.rs
@@ -36,7 +36,7 @@ pub struct DataArchetypeBuildOnly {
 
 #[derive(Debug)]
 pub enum DataCapacity {
-    Expression(Expr),
+    Fixed(Expr),
     Dynamic,
 }
 
@@ -128,7 +128,7 @@ impl DataArchetype {
 
 fn convert_capacity(capacity: ParseCapacity) -> DataCapacity {
     match capacity {
-        ParseCapacity::Expression(expr) => DataCapacity::Expression(expr),
+        ParseCapacity::Fixed(expr) => DataCapacity::Fixed(expr),
         ParseCapacity::Dynamic => DataCapacity::Dynamic,
     }
 }

--- a/macros/src/generate/world.rs
+++ b/macros/src/generate/world.rs
@@ -39,6 +39,16 @@ pub fn generate_world(world_data: &DataWorld, raw_input: &str) -> TokenStream {
         .iter()
         .map(|archetype| section_archetype(archetype))
         .collect::<Vec<_>>();
+    let with_capacity_param = world_data
+        .archetypes
+        .iter()
+        .map(|archetype| with_capacity_param(archetype))
+        .collect::<Vec<_>>();
+    let with_capacity_new = world_data
+        .archetypes
+        .iter()
+        .map(|archetype| with_capacity_new(archetype))
+        .collect::<Vec<_>>();
 
     // Macros
     let __ecs_find_unique = format_ident!("__ecs_find_{}", unique_hash);
@@ -67,6 +77,35 @@ pub fn generate_world(world_data: &DataWorld, raw_input: &str) -> TokenStream {
             }
 
             impl #World {
+                /// Creates a new empty world.
+                ///
+                /// This will allocate for all fixed-size archetypes, but not allocate for
+                /// any dynamic archetypes. Dynamic archetypes will begin with 0 capacity.
+                pub fn new() -> Self {
+                    Self {
+                        #( #archetype: #Archetype::new(), )*
+                    }
+                }
+
+                /// Creates a new world with per-archetype capacities.
+                ///
+                /// Expects a capacity value for every dynamic archetype.
+                ///
+                /// This will allocate all archetypes to either their fixed size, or the given
+                /// dynamic capacity. If a given dynamic capacity is 0, that archetype will not
+                /// allocate until an entity is pushed into it.
+                ///
+                /// # Panics
+                ///
+                /// This will panic if given a size that exceeds the maximum possible capacity
+                /// value for an archetype (currently `16,777,216`).
+                pub fn with_capacity(#(#with_capacity_param)*) -> Self {
+                    Self {
+                        #( #archetype: #Archetype::#with_capacity_new, )*
+                    }
+                }
+
+
                 /// Removes a given entity of any type from the world, if it exists.
                 ///
                 /// Return `true` if the entity was successfully removed, or `false` otherwise.
@@ -449,6 +488,24 @@ fn section_archetype(archetype_data: &DataArchetype) -> TokenStream {
             }
         }
     )
+}
+
+#[allow(non_snake_case)]
+fn with_capacity_param(archetype_data: &DataArchetype) -> TokenStream {
+    let archetype_capacity = format_ident!("capacity_{}", to_snake(&archetype_data.name));
+    match archetype_data.build_data.as_ref().unwrap().capacity {
+        DataCapacity::Fixed(_) => quote!(),
+        DataCapacity::Dynamic => quote!(#archetype_capacity: usize,),
+    }
+}
+
+#[allow(non_snake_case)]
+fn with_capacity_new(archetype_data: &DataArchetype) -> TokenStream {
+    let archetype_capacity = format_ident!("capacity_{}", to_snake(&archetype_data.name));
+    match archetype_data.build_data.as_ref().unwrap().capacity {
+        DataCapacity::Fixed(_) => quote!(new()),
+        DataCapacity::Dynamic => quote!(with_capacity(#archetype_capacity)),
+    }
 }
 
 fn to_snake(name: &String) -> String {

--- a/macros/src/parse/world.rs
+++ b/macros/src/parse/world.rs
@@ -88,8 +88,8 @@ pub enum ParseAttributeData {
 
 #[derive(Debug)]
 pub enum ParseCapacity {
+    Fixed(Expr),
     Dynamic,
-    Expression(Expr),
 }
 
 impl ParseEcsWorld {
@@ -352,7 +352,7 @@ impl Parse for ParseCapacity {
             input.parse::<Dyn>()?;
             Ok(ParseCapacity::Dynamic)
         } else {
-            input.parse().map(ParseCapacity::Expression)
+            input.parse().map(ParseCapacity::Fixed)
         }
     }
 }

--- a/src/archetype/slot.rs
+++ b/src/archetype/slot.rs
@@ -1,39 +1,105 @@
 use std::num::NonZeroU32;
 
 use crate::error::EcsError;
+use crate::index::{DataIndex, MAX_DATA_INDEX};
+use crate::util::num_assert_lt;
 
+// This is a slightly messy hack to create a NonZeroU32 constant.
 const VERSION_START: NonZeroU32 = match NonZeroU32::new(1) {
     Some(v) => v,
     None => [][0],
 };
-const FREE_BIT: u32 = 0x80000000;
 
+// We use the highest order bit to mark which indices are free list.
+// This is necessary because we need to catch if a bad entity handle
+// (say, from a different ECS world) tries to access a freed slot and
+// treat it as a live data slot, which could cause OOB memory access.
+const FREE_BIT: u32 = 1 << 31;
+
+// This is a reserved index marking the end of the free list. It should
+// always be bigger than the maximum index we can store in an entity/slot.
+const FREE_LIST_END: u32 = FREE_BIT - 1;
+
+/// The data index stored in a slot.
+///
+/// This can point to entity data, or be a member of the slot free list.
 #[derive(Clone, Copy)]
-pub(crate) struct Slot {
-    index: u32,
-    version: NonZeroU32,
-}
+pub(crate) struct SlotIndex(u32);
 
-impl Slot {
+impl SlotIndex {
+    /// Creates a new SlotIndex at the end of the free list.
     #[inline(always)]
-    pub(crate) fn new(next_free: u32) -> Self {
-        debug_assert!(next_free <= !FREE_BIT);
-        Self {
-            index: next_free | FREE_BIT,
-            version: VERSION_START,
-        }
+    pub(crate) fn new_free_end() -> Self {
+        Self(FREE_BIT | FREE_LIST_END)
     }
 
-    /// Gets the slot's index value when representing a data pointer.
-    #[inline(always)]
-    pub(crate) fn index(&self) -> u32 {
-        self.index & (!FREE_BIT)
+    /// Creates a new SlotIndex pointing to another slot in the free list.
+    pub(crate) fn new_free(next_free: DataIndex) -> Self {
+        Self(FREE_BIT | next_free.get())
     }
 
     /// Returns true if this slot is freed.
     #[inline(always)]
     pub(crate) fn is_free(&self) -> bool {
-        (self.index & FREE_BIT) != 0
+        (FREE_BIT & self.0) != 0
+    }
+
+    /// Returns the data index this slot points to.
+    /// Will be `None` if the index is a free list index.
+    #[inline(always)]
+    pub(crate) fn get_data(&self) -> Option<DataIndex> {
+        debug_assert!(self.is_free() == false);
+        DataIndex::new(self.0)
+    }
+
+    /// Returns the free list index this slot points to.
+    /// Will be `None` if the index is the free list end.
+    #[inline(always)]
+    pub(crate) fn get_next_free(&self) -> Option<DataIndex> {
+        // This only works if FREE_LIST_END is too big to fit in a DataIndex.
+        // We also verify this in verify_free_list_end_is_invalid_data_index.
+        num_assert_lt!(MAX_DATA_INDEX as usize, FREE_LIST_END as usize);
+
+        debug_assert!(self.is_free());
+        DataIndex::new(!FREE_BIT & self.0)
+    }
+
+    /// Assigns a slot to some non-free data index.
+    /// This may be a reassignment of an already live slot.
+    #[inline(always)]
+    pub(crate) fn assign_data(&mut self, index_data: DataIndex) {
+        self.0 = index_data.get();
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Slot {
+    index: SlotIndex,
+    version: NonZeroU32,
+}
+
+impl Slot {
+    #[inline(always)]
+    pub(crate) fn new_free(next_free: SlotIndex) -> Self {
+        // Make sure that there is room in the index for the free bit.
+        num_assert_lt!(MAX_DATA_INDEX as usize, FREE_BIT as usize);
+
+        Self {
+            index: next_free,
+            version: VERSION_START,
+        }
+    }
+
+    /// Returns this slot's index. May point to data or a free list entry.
+    #[inline(always)]
+    pub(crate) fn index(&self) -> SlotIndex {
+        self.index
+    }
+
+    /// Returns true if this slot is freed.
+    #[inline(always)]
+    pub(crate) fn is_free(&self) -> bool {
+        self.index.is_free()
     }
 
     /// Get the slot's generational version.
@@ -44,26 +110,36 @@ impl Slot {
 
     /// Assigns a slot to some data. This does not increment the version.
     #[inline(always)]
-    pub(crate) fn assign(&mut self, index_data: u32) {
-        self.index = index_data;
+    pub(crate) fn assign(&mut self, index_data: DataIndex) {
+        self.index.assign_data(index_data);
 
-        // We increment the version counter on release, not assignment
+        // NOTE: We increment the version on release, not assignment.
     }
 
     /// Releases a slot and increments its version, invalidating all handles.
     /// Returns an `EcsError::VersionOverflow` if the version increment overflows.
     #[inline(always)]
-    pub(crate) fn release(&mut self, index_free: u32) -> Result<(), EcsError> {
+    pub(crate) fn release(&mut self, index_next_free: SlotIndex) -> Result<(), EcsError> {
         debug_assert!(self.is_free() == false);
+        self.index = index_next_free;
 
-        self.index = index_free | FREE_BIT;
-
-        // We increment the version counter on release, not assignment
+        // Increment the version to invalidate all previous handles to this slot.
+        // This prevents bad access from stale entity handles after moving the data.
         if let Some(version) = self.version.checked_add(1) {
             self.version = version;
             Ok(())
         } else {
+            // The version could overflow after u32::MAX rewrites. This is very unlikely,
+            // but irrecoverable for this slot if it happens. We can't wrap, since that
+            // could make some stale entity handles valid again. We just have to fail.
             Err(EcsError::VersionOverflow)
         }
     }
+}
+
+// Need to enforce this invariant here just in case.
+// If this isn't true, then we can't trust the FREE_LIST_END value.
+#[test]
+fn verify_free_list_end_is_invalid_data_index() {
+    assert!(DataIndex::new(FREE_LIST_END).is_none());
 }

--- a/src/archetype/storage_dynamic.rs
+++ b/src/archetype/storage_dynamic.rs
@@ -1,621 +1,630 @@
-// TODO: Allow users to specify `dyn` as the capacity argument for archetypes.
-// Archetypes specified in this way will be backed by Vec-like dynamic storage.
-
-use std::alloc::{self, Layout};
-use std::array;
-use std::cell::{Ref, RefCell, RefMut};
-use std::mem::{self, MaybeUninit};
-use std::ptr::{self, NonNull};
-use std::slice;
-
-use paste::paste;
-
-use crate::archetype::slices::*;
-use crate::archetype::slot::Slot;
-use crate::entity::{Entity, EntityIndex, MAX_ARCHETYPE_CAPACITY};
-use crate::traits::Archetype;
-use crate::util::{debug_checked_assume, num_assert_leq, num_assert_lt};
-
-macro_rules! declare_storage_dynamic_n {
-    ($n:literal, $($i:literal),+) => {
-        paste! {
-            pub struct [<StorageDynamic$n>]<A: Archetype, $([<T$i>],)+> {
-                len: usize,
-                capacity: usize,
-                free_head: u32,
-                slots: DataDynamic<Slot>, // Sparse
-                // No RefCell here since we never grant mutable access externally
-                entities: DataDynamic<Entity<A>>,
-                $([<d$i>]: RefCell<DataDynamic<[<T$i>]>>,)+
-            }
-
-            impl<A: Archetype, $([<T$i>],)+> [<StorageDynamic$n>]<A, $([<T$i>],)+>
-            {
-                #[inline(always)]
-                pub fn new() -> Self {
-                    // We assume in a lot of places that u32 can trivially convert to usize
-                    num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
-                    let slots = DataDynamic::new(); // Don't need to populate
-
-                    Self {
-                        len: 0,
-                        capacity: 0,
-                        free_head: 0,
-                        slots,
-                        entities: DataDynamic::new(),
-                        $([<d$i>]: RefCell::new(DataDynamic::new()),)+
-                    }
-                }
-
-                #[inline(always)]
-                pub fn with_capacity(capacity: usize) -> Self {
-                    if (capacity > MAX_ARCHETYPE_CAPACITY as usize) {
-                        panic!("capacity may not exceed {}", MAX_ARCHETYPE_CAPACITY);
-                    }
-
-                    // We assume in a lot of places that u32 can trivially convert to usize
-                    num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
-                    let mut slots = DataDynamic::with_capacity(capacity);
-                    // SAFETY: We guarantee the free list is allocated to capacity
-                    unsafe { fill_free_list(&mut slots, 0, capacity) };
-
-                    Self {
-                        len: 0,
-                        capacity: 0,
-                        free_head: 0,
-                        slots,
-                        entities: DataDynamic::with_capacity(capacity),
-                        $([<d$i>]: RefCell::new(DataDynamic::with_capacity(capacity)),)+
-                    }
-                }
-
-                #[inline(always)]
-                pub const fn len(&self) -> usize {
-                    self.len
-                }
-
-                #[inline(always)]
-                pub const fn is_empty(&self) -> bool {
-                    self.len == 0
-                }
-
-                #[inline(always)]
-                pub const fn capacity(&self) -> usize {
-                    self.capacity
-                }
-
-                // /// Reserves a slot in the map pointing to the given dense index.
-                // /// Returns an entity handle if successful, or None if we're full.
-                // #[inline(always)]
-                // pub fn try_push(&mut self, data: ($([<T$i>],)+)) -> Option<Entity<A>> {
-                //     if self.len >= N {
-                //         return None;
-                //     }
-
-                //     // We know that self.len < N, and N <= u32::MAX
-                //     let dense_index: u32 = self.len as u32;
-                //     let slot_index: u32 = self.free_head;
-
-                //     // This means we're at the end of the free list
-                //     if (slot_index as usize) >= N {
-                //         return None;
-                //     }
-
-                //     unsafe {
-                //         debug_assert!((slot_index as usize) < N);
-                //         debug_assert!(slot_index < MAX_ARCHETYPE_CAPACITY);
-
-                //         // SAFETY: We know that slot_index < N
-                //         let slot = self.slots.get_unchecked_mut(slot_index as usize);
-                //         // SAFETY: We know that slot_index < MAX_ARCHETYPE_CAPACITY
-                //         let entity_index = EntityIndex::new_unchecked(slot_index);
-
-                //         // NOTE: Do not change the following order of operations!
-                //         debug_assert!(slot.is_free());
-                //         self.free_head = slot.index();
-                //         slot.assign(dense_index);
-                //         let entity = Entity::new(entity_index, slot.version());
-                //         let index = self.len;
-                //         self.len += 1;
-
-                //         // SAFETY: We can't overflow because self.len < N.
-                //         debug_checked_assume!(index < self.len);
-
-                //         // SAFETY: We know that index < N and points to an empty cell.
-                //         //////////self.entities.slice_mut(self.len)[index] = entity;
-                //         //////////$(self.[<d$i>].get_mut().slice_mut(self.len)[index] = data.$i;)+
-
-                //         Some(entity)
-                //     }
-                // }
-
-                // /// Resolves an entity to an index in the storage data slices.
-                // /// This index is guaranteed to be in bounds and point to valid data.
-                // #[inline(always)]
-                // pub fn resolve(&self, entity: Entity<A>) -> Option<usize> {
-                //     let (_, dense_index) = match self.resolve_slot(entity) {
-                //         None => { return None; }
-                //         Some(found) => found,
-                //     };
-
-                //     let dense_index = dense_index.try_into().unwrap();
-
-                //     unsafe {
-                //         // SAFETY: resolve_slot guarantees this index is valid.
-                //         // We assume this to help avoid bounds checks later on.
-                //         debug_checked_assume!(dense_index < self.len);
-                //     }
-
-                //     Some(dense_index)
-                // }
-
-                // /// Removes the given entity from storage if it exists there.
-                // /// Returns the removed entity's components, if any.
-                // #[inline(always)]
-                // pub fn remove(&mut self, entity: Entity<A>) -> Option<($([<T$i>],)*)> {
-                //     let (slot_index, dense_index) = match self.resolve_slot(entity) {
-                //         None => { return None; }
-                //         Some(found) => found,
-                //     };
-
-                //     let result = unsafe {
-                //         // SAFETY: These are guaranteed by resolve_slot to be in range.
-                //         let slot_index_usize: usize = slot_index.try_into().unwrap();
-                //         let dense_index_usize: usize = dense_index.try_into().unwrap();
-
-                //         debug_assert!(self.len > 0);
-                //         debug_assert!(self.len <= N);
-                //         debug_assert!(slot_index_usize <= N);
-                //         debug_assert!(dense_index_usize <= N);
-                //         debug_assert!(dense_index_usize < self.len);
-
-                //         let entities = self.entities.slice(self.len);
-                //         debug_assert!(entities.len() == self.len);
-                //         debug_assert!(entities[dense_index_usize].index() == entity.index());
-                //         debug_assert!(entities[dense_index_usize].version() == entity.version());
-
-                //         // SAFETY: We know that self.len > 0 from the early-out check above.
-                //         let last_dense_index = self.len - 1;
-                //         // SAFETY: We know the entity slice has a length of self.len.
-                //         let last_entity = *entities.get_unchecked(last_dense_index);
-                //         // SAFETY: We guarantee that stored entities point to valid slots.
-                //         let last_slot_index: usize = last_entity.index().try_into().unwrap();
-
-                //         // Perform the swap_remove on our data to drop the target entity.
-                //         // SAFETY: We guarantee that non-free slots point to valid dense data.
-                //         self.entities.swap_remove(dense_index_usize, self.len);
-                //         let result =
-                //             ($(self.[<d$i>].get_mut().swap_remove(dense_index_usize, self.len),)+);
-
-                //         // NOTE: Order matters here to support the (target == last) case!
-                //         // Fix up the slot pointing to the last entity
-                //         self.slots
-                //             .get_unchecked_mut(last_slot_index) // SAFETY: See declaration.
-                //             .assign(dense_index);
-                //         // Return the target slot to the free list
-                //         self.slots
-                //             .get_unchecked_mut(slot_index_usize) // SAFETY: See declaration.
-                //             .release(self.free_head)
-                //             .expect("slot version overflow"); // TODO: Orphan this slot?
-
-                //         result
-                //     };
-
-                //     // TODO: We shouldn't add a slot to the free list if its version number
-                //     // is maxed out. It would be better to orphan that slot to avoid issues.
-
-                //     // Update the free list head
-                //     self.free_head = entity.index();
-                //     self.len -= 1;
-
-                //     Some(result)
-                // }
-
-                /// Populates a slice struct with slices to our stored data.
-                #[inline(always)]
-                pub fn get_all_slices<'a, S: [<Slices$n>]<'a, A, $([<T$i>],)+>>(&'a mut self,) -> S {
-                    unsafe {
-                        // SAFETY: We guarantee that the storage is valid up to self.len.
-                        S::new(
-                            self.entities.slice(self.len),
-                            $(self.[<d$i>].get_mut().slice_mut(self.len)),+
-                        )
-                    }
-                }
-
-                /// Gets a read-only slice of our currently stored entity handles.
-                #[inline(always)]
-                pub fn get_slice_entities(&self) -> &[Entity<A>] {
-                    unsafe {
-                        // SAFETY: We guarantee that the storage is valid up to self.len.
-                        self.entities.slice(self.len)
-                    }
-                }
-
-                $(
-                    /// Gets a slice of the given component index.
-                    #[inline(always)]
-                    pub fn [<get_slice_$i>](&mut self) -> &[[<T$i>]] {
-                        unsafe {
-                            // SAFETY: We guarantee that the storage is valid up to self.len.
-                            self.[<d$i>].get_mut().slice(self.len)
-                        }
-                    }
-
-                    /// Gets a slice of the given component index.
-                    #[inline(always)]
-                    pub fn [<get_slice_mut_$i>](&mut self) -> &mut [[<T$i>]] {
-                        unsafe {
-                            // SAFETY: We guarantee that the storage is valid up to self.len.
-                            self.[<d$i>].get_mut().slice_mut(self.len)
-                        }
-                    }
-
-                    /// Borrows the slice of the given component index.
-                    #[inline(always)]
-                    pub fn [<borrow_slice_$i>](&self) -> Ref<[[<T$i>]]> {
-                        Ref::map(self.[<d$i>].borrow(), |slice| unsafe {
-                            // SAFETY: We guarantee that the storage is valid up to self.len.
-                            slice.slice(self.len)
-                        })
-                    }
-
-                    /// Mutably borrows the slice of the given component index.
-                    #[inline(always)]
-                    pub fn [<borrow_slice_mut_$i>](&self) -> RefMut<[[<T$i>]]> {
-                        RefMut::map(self.[<d$i>].borrow_mut(), |slice| unsafe {
-                            // SAFETY: We guarantee that the storage is valid up to self.len.
-                            slice.slice_mut(self.len)
-                        })
-                    }
-                )+
-
-                /// Resolves the slot index and data index for a given entity.
-                /// Both indices are guaranteed to point to valid cells.
-                #[inline(always)]
-                fn resolve_slot(&self, entity: Entity<A>) -> Option<(u32, u32)> {
-                    // Nothing to resolve if we have nothing stored
-                    if self.len == 0 {
-                        return None;
-                    }
-
-                    // Get the index into the slot array from the entity.
-                    let slot_index = entity.index();
-
-                    let slot = unsafe {
-                        // NOTE: It's a little silly, but we don't actually know if this entity
-                        // was created by this map, so we can't assume internal consistency here.
-                        // We'll just have to take the small hit for bounds checking on the index.
-                        if slot_index as usize >= self.capacity {
-                            panic!("entity handle is invalid for this archetype");
-                        }
-
-                        // SAFETY: We guarantee that the array is allocated up to self.capacity.
-                        // SAFETY: We guarantee that the slot index is less than self.capacity.
-                        self.slots.slice(self.capacity).get_unchecked(slot_index as usize)
-                    };
-
-                    if (slot.version() != entity.version()) || slot.is_free() {
-                        return None; // Stale entity handle, fail the lookup
-                    }
-
-                    // Get the index into the dense array from the slot.
-                    let dense_index = slot.index();
-
-                    Some((slot_index, dense_index))
-                }
-            }
-
-            impl<A: Archetype, $([<T$i>],)+> Drop
-                for [<StorageDynamic$n>]<A, $([<T$i>],)+>
-            {
-                #[inline(always)]
-                fn drop(&mut self) {
-                    // SAFETY: We guarantee that the storage is valid up to self.len.
-                    unsafe {
-                        $(self.[<d$i>].get_mut().drop_to(self.len);)+
-                        // We don't need to drop the other stuff since it's all trivial.
-                    };
-                }
-            }
-
-            impl<A: Archetype, $([<T$i>],)+> Default
-                for [<StorageDynamic$n>]<A, $([<T$i>],)+>
-            {
-                #[inline(always)]
-                fn default() -> Self {
-                    [<StorageDynamic$n>]::new()
-                }
-            }
-        }
-    };
-}
-
-// declare_storage_dynamic_n!(1, 0);
-// declare_storage_dynamic_n!(2, 0, 1);
-// declare_storage_dynamic_n!(3, 0, 1, 2);
-declare_storage_dynamic_n!(4, 0, 1, 2, 3);
-// declare_storage_dynamic_n!(5, 0, 1, 2, 3, 4);
-// declare_storage_dynamic_n!(6, 0, 1, 2, 3, 4, 5);
-// declare_storage_dynamic_n!(7, 0, 1, 2, 3, 4, 5, 6);
-// declare_storage_dynamic_n!(8, 0, 1, 2, 3, 4, 5, 6, 7);
-// declare_storage_dynamic_n!(9, 0, 1, 2, 3, 4, 5, 6, 7, 8);
-// declare_storage_dynamic_n!(10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-// declare_storage_dynamic_n!(11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-// declare_storage_dynamic_n!(12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-// declare_storage_dynamic_n!(13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-// declare_storage_dynamic_n!(14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-// declare_storage_dynamic_n!(15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-// declare_storage_dynamic_n!(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-
-/// Populates a free list in the range start..capacity with a fresh free list.
-///
-/// # Safety
-///
-/// It is up to the caller to guarantee the following:
-/// - `array` has allocated at least `capacity` elements
-/// - `start <= capacity`
-/// - `capacity < u32::MAX`
-#[inline(always)]
-unsafe fn fill_free_list(array: &mut DataDynamic<Slot>, start: usize, capacity: usize) {
-    unsafe {
-        // SAFETY: The caller guarantees start <= capacity
-        debug_checked_assume!(start <= capacity);
-        debug_checked_assume!(capacity <= u32::MAX as usize);
-
-        // NOTE: The last slot will point off the end of the free list.
-        // In practice, we should never read this value anyway, since
-        // we'd only ask to reserve when the dense list has room. However,
-        // we may still want to check in the future if we decide to orphan
-        // slots with overflowed versions (since we'd then have fewer slots
-        // than dense list space). We'll need to revisit this logic if so.
-        for i in start..capacity {
-            array.write(i, Slot::new((i as u32) + 1));
-        }
-    }
-}
-
-pub struct DataDynamic<T>(NonNull<MaybeUninit<T>>);
-
-impl<T> DataDynamic<T> {
-    /// Creates a new empty data array. This does not allocate.
-    pub fn new() -> Self {
-        Self(NonNull::dangling())
-    }
-
-    /// Allocates a new data array with the given capacity, if any.
-    ///
-    ///
-    /// # Panics
-    ///
-    /// This operation will panic if there is not enough memory to perform the new
-    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
-    pub fn with_capacity(new_capacity: usize) -> Self {
-        if (mem::size_of::<T>() == 0) || (new_capacity == 0) {
-            return Self(NonNull::dangling());
-        }
-
-        let new_lay = new_layout::<T>(new_capacity);
-
-        debug_assert!(new_capacity > 0);
-        debug_assert!(new_lay.size() > 0);
-
-        unsafe { Self(resolve_ptr(alloc::alloc(new_lay), new_lay)) }
-    }
-
-    /// Allocates a new block of data for this array.
-    ///
-    /// If this array already has allocated memory, that memory will be leaked.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - `new_capacity > 0`
-    ///
-    /// # Panics
-    ///
-    /// This operation will panic if there is not enough memory to perform the new
-    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
-    pub unsafe fn alloc(&mut self, new_capacity: usize) {
-        if mem::size_of::<T>() == 0 {
-            return;
-        }
-
-        let new_layout = new_layout::<T>(new_capacity);
-
-        debug_assert!(new_capacity > 0);
-        debug_assert!(new_layout.size() > 0);
-
-        unsafe {
-            self.0 = resolve_ptr(
-                // SAFETY: We know that new_layout has a nonzero size.
-                alloc::alloc(new_layout),
-                new_layout,
-            );
-        }
-    }
-
-    /// Reallocates this array's old data block into a new data block.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - `new_capacity > 0`
-    /// - `new_capacity >= old_capacity`
-    /// - This array has exactly `old_capacity` elements allocated
-    ///
-    /// # Panics
-    ///
-    /// This operation will panic if there is not enough memory to perform the new
-    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
-    pub unsafe fn realloc(&mut self, old_capacity: usize, new_capacity: usize) {
-        if mem::size_of::<T>() == 0 {
-            return;
-        }
-
-        if old_capacity == 0 {
-            // SAFETY: The caller guarantees that new_capacity > 0.
-            unsafe { self.alloc(new_capacity) };
-            return;
-        }
-
-        let old_ptr = self.0.as_ptr() as *mut u8;
-        let new_layout = new_layout::<T>(new_capacity);
-        let old_layout = Layout::array::<T>(old_capacity).unwrap();
-
-        debug_assert!(new_capacity > 0);
-        debug_assert!(old_capacity > 0);
-        debug_assert!(new_capacity >= old_capacity);
-        debug_assert!(new_layout.size() > 0);
-        debug_assert!(old_layout.size() > 0);
-        debug_assert!(old_ptr.is_null() == false);
-
-        unsafe {
-            self.0 = resolve_ptr(
-                // SAFETY: We know that both layouts have a nonzero size.
-                alloc::realloc(old_ptr, old_layout, new_layout.size()),
-                new_layout,
-            );
-        }
-    }
-
-    /// Deallocates this array's data block.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - This array has exactly `old_capacity` elements allocated
-    pub unsafe fn dealloc(&mut self, old_capacity: usize) {
-        if mem::size_of::<T>() == 0 {
-            return;
-        }
-
-        if old_capacity == 0 {
-            return;
-        }
-
-        let old_layout = Layout::array::<T>(old_capacity).unwrap();
-
-        debug_assert!(old_capacity > 0);
-        debug_assert!(old_layout.size() > 0);
-
-        unsafe {
-            // SAFETY: We know that old_layout has a nonzero size
-            alloc::dealloc(self.0.as_ptr() as *mut u8, old_layout);
-            self.0 = NonNull::dangling();
-        }
-    }
-
-    /// Writes an element to the given index.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - This pointer has allocated at least `index` elements
-    /// - The element at `index` is not currently initialized
-    #[inline(always)]
-    unsafe fn write(&mut self, index: usize, val: T) {
-        unsafe {
-            // SAFETY: The caller guarantees that this slot is allocated and uninitialized.
-            (*self.0.as_ptr().add(index)).write(val);
-        }
-    }
-
-    /// Gets a slice for the range `0..len`.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - This pointer has allocated at least `len` elements
-    /// - All elements the range `0..len` are initialized
-    #[inline(always)]
-    unsafe fn slice(&self, len: usize) -> &[T] {
-        // SAFETY: Casting `slice` to a `*const [T]` is safe since the caller guarantees that
-        // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
-        // The pointer obtained is valid since it refers to memory owned by `slice` which is a
-        // reference and thus guaranteed to be valid for reads.
-        // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#972
-        unsafe { slice::from_raw_parts(self.0.as_ptr() as *const T, len) }
-    }
-
-    /// Gets a mutable slice for the range `0..len`.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - This pointer has allocated at least `len` elements
-    /// - All elements the range `0..len` are valid data
-    #[inline(always)]
-    unsafe fn slice_mut(&mut self, len: usize) -> &mut [T] {
-        // SAFETY: Similar to safety notes for `assume_init_slice`, but we have a
-        // mutable reference which is also guaranteed to be valid for writes.
-        // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#994
-        unsafe { slice::from_raw_parts_mut(self.0.as_ptr() as *mut T, len) }
-    }
-
-    /// Drops the element at `index` and replaces it with the last element in `0..len`.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - This pointer has allocated at least `len` elements
-    /// - All elements the range `0..len` are initialized
-    /// - `len > 0`
-    /// - `index < len`
-    #[inline(always)]
-    unsafe fn swap_remove(&mut self, index: usize, len: usize) -> T {
-        unsafe {
-            // SAFETY: These are all guaranteed by the caller and stated above.
-            debug_checked_assume!(len > 0);
-            debug_checked_assume!(index < len);
-
-            // SAFETY: The caller is guaranteeing that the element at index, and
-            // the element at len - 1 are both valid. With this guarantee we can
-            // safely take the element at index. We then perform a direct pointer
-            // copy (we can't assume nonoverlapping here!) from the last element
-            // to the one at index. This moves the data, making the data at index
-            // initialized to the data at last, and the data at last effectively
-            // uninitialized (though bitwise identical to the data at index).
-            let last = len - 1;
-            let array_ptr = self.0.as_ptr();
-            let result = ptr::read(array_ptr.add(index)).assume_init();
-            ptr::copy(array_ptr.add(last), array_ptr.add(index), 1);
-            *array_ptr.add(last) = MaybeUninit::uninit(); // Hint for Miri
-            result
-        }
-    }
-
-    /// Drops all elements in the range `0..len`.
-    ///
-    /// # Safety
-    ///
-    /// It is up to the caller to guarantee the following:
-    /// - All elements in the range `0..len` are initialized
-    /// - `len <= N`
-    #[inline(always)]
-    unsafe fn drop_to(&mut self, len: usize) {
-        unsafe {
-            for i in 0..len {
-                let i_ptr = self.0.as_ptr().add(i);
-                // SAFETY: The caller guarantees this element is valid.
-                ptr::drop_in_place(i_ptr as *mut T);
-                ptr::write(i_ptr, MaybeUninit::uninit()); // Hint for Miri
-            }
-        };
-    }
-}
-
-#[inline(always)]
-fn new_layout<T>(capacity: usize) -> Layout {
-    let layout = Layout::array::<T>(capacity).unwrap();
-    assert!(layout.size() <= isize::MAX as usize, "allocation too large");
-    layout
-}
-
-#[inline(always)]
-fn resolve_ptr<T>(ptr: *mut u8, layout: Layout) -> NonNull<T> {
-    match NonNull::new(ptr as *mut T) {
-        Some(p) => p,
-        None => alloc::handle_alloc_error(layout),
-    }
-}
+// // TODO: Allow users to specify `dyn` as the capacity argument for archetypes.
+// // Archetypes specified in this way will be backed by Vec-like dynamic storage.
+
+// use std::alloc::{self, Layout};
+// use std::array;
+// use std::cell::{Ref, RefCell, RefMut};
+// use std::mem::{self, MaybeUninit};
+// use std::ptr::{self, NonNull};
+// use std::slice;
+
+// use paste::paste;
+
+// use crate::archetype::slices::*;
+// use crate::archetype::slot::Slot;
+// use crate::entity::Entity;
+// use crate::index::{DataIndex, MAX_DATA_CAPACITY};
+// use crate::traits::Archetype;
+// use crate::util::{debug_checked_assume, num_assert_leq, num_assert_lt};
+
+// macro_rules! declare_storage_dynamic_n {
+//     ($n:literal, $($i:literal),+) => {
+//         paste! {
+//             pub struct [<StorageDynamic$n>]<A: Archetype, $([<T$i>],)+> {
+//                 len: usize,
+//                 capacity: usize,
+//                 free_head: u32,
+//                 slots: DataDynamic<Slot>, // Sparse
+//                 // No RefCell here since we never grant mutable access externally
+//                 entities: DataDynamic<Entity<A>>,
+//                 $([<d$i>]: RefCell<DataDynamic<[<T$i>]>>,)+
+//             }
+
+//             impl<A: Archetype, $([<T$i>],)+> [<StorageDynamic$n>]<A, $([<T$i>],)+>
+//             {
+//                 #[inline(always)]
+//                 pub fn new() -> Self {
+//                     // We assume in a lot of places that u32 can trivially convert to usize
+//                     num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
+//                     let slots = DataDynamic::new(); // Don't need to populate
+
+//                     Self {
+//                         len: 0,
+//                         capacity: 0,
+//                         free_head: 0,
+//                         slots,
+//                         entities: DataDynamic::new(),
+//                         $([<d$i>]: RefCell::new(DataDynamic::new()),)+
+//                     }
+//                 }
+
+//                 #[inline(always)]
+//                 pub fn with_capacity(capacity: usize) -> Self {
+//                     if (capacity > MAX_DATA_CAPACITY as usize) {
+//                         panic!("capacity may not exceed {}", MAX_DATA_CAPACITY);
+//                     }
+
+//                     // We assume in a lot of places that u32 can trivially convert to usize
+//                     num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
+//                     let mut slots = DataDynamic::with_capacity(capacity);
+//                     // SAFETY: We guarantee the free list is allocated to capacity
+//                     unsafe { fill_free_list(&mut slots, 0, capacity) };
+
+//                     Self {
+//                         len: 0,
+//                         capacity: 0,
+//                         free_head: 0,
+//                         slots,
+//                         entities: DataDynamic::with_capacity(capacity),
+//                         $([<d$i>]: RefCell::new(DataDynamic::with_capacity(capacity)),)+
+//                     }
+//                 }
+
+//                 #[inline(always)]
+//                 pub const fn len(&self) -> usize {
+//                     self.len
+//                 }
+
+//                 #[inline(always)]
+//                 pub const fn is_empty(&self) -> bool {
+//                     self.len == 0
+//                 }
+
+//                 #[inline(always)]
+//                 pub const fn capacity(&self) -> usize {
+//                     self.capacity
+//                 }
+
+//                 // /// Reserves a slot in the map pointing to the given dense index.
+//                 // /// Returns an entity handle if successful, or None if we're full.
+//                 // #[inline(always)]
+//                 // pub fn try_push(&mut self, data: ($([<T$i>],)+)) -> Option<Entity<A>> {
+//                 //     if self.len >= N {
+//                 //         return None;
+//                 //     }
+
+//                 //     // We know that self.len < N, and N <= u32::MAX
+//                 //     let dense_index: u32 = self.len as u32;
+//                 //     let slot_index: u32 = self.free_head;
+
+//                 //     // This means we're at the end of the free list
+//                 //     if (slot_index as usize) >= N {
+//                 //         return None;
+//                 //     }
+
+//                 //     unsafe {
+//                 //         debug_assert!((slot_index as usize) < N);
+//                 //         debug_assert!(slot_index < MAX_DATA_CAPACITY);
+
+//                 //         // SAFETY: We know that slot_index < N
+//                 //         let slot = self.slots.get_unchecked_mut(slot_index as usize);
+//                 //         // SAFETY: We know that slot_index < MAX_DATA_CAPACITY
+//                 //         let entity_index = EntityIndex::new_unchecked(slot_index);
+
+//                 //         // NOTE: Do not change the following order of operations!
+//                 //         debug_assert!(slot.is_free());
+//                 //         self.free_head = slot.index();
+//                 //         slot.assign(dense_index);
+//                 //         let entity = Entity::new(entity_index, slot.version());
+//                 //         let index = self.len;
+//                 //         self.len += 1;
+
+//                 //         // SAFETY: We can't overflow because self.len < N.
+//                 //         debug_checked_assume!(index < self.len);
+
+//                 //         // SAFETY: We know that index < N and points to an empty cell.
+//                 //         //////////self.entities.slice_mut(self.len)[index] = entity;
+//                 //         //////////$(self.[<d$i>].get_mut().slice_mut(self.len)[index] = data.$i;)+
+
+//                 //         Some(entity)
+//                 //     }
+//                 // }
+
+//                 /// Resolves an entity to an index in the storage data slices.
+//                 /// This index is guaranteed to be in bounds and point to valid data.
+//                 #[inline(always)]
+//                 pub fn resolve(&self, entity: Entity<A>) -> Option<usize> {
+//                     let (_, dense_index) = match self.resolve_slot(entity) {
+//                         None => { return None; }
+//                         Some(found) => found,
+//                     };
+
+//                     let dense_index = dense_index.try_into().unwrap();
+
+//                     unsafe {
+//                         // SAFETY: resolve_slot guarantees this index is valid.
+//                         // We assume this to help avoid bounds checks later on.
+//                         debug_checked_assume!(dense_index < self.len);
+//                     }
+
+//                     Some(dense_index)
+//                 }
+
+//                 /// Removes the given entity from storage if it exists there.
+//                 /// Returns the removed entity's components, if any.
+//                 #[inline(always)]
+//                 pub fn remove(&mut self, entity: Entity<A>) -> Option<($([<T$i>],)*)> {
+//                     let (slot_index, dense_index) = match self.resolve_slot(entity) {
+//                         None => { return None; }
+//                         Some(found) => found,
+//                     };
+
+//                     let result = unsafe {
+//                         // SAFETY: These are guaranteed by resolve_slot to be in range.
+//                         let slot_index_usize: usize = slot_index.try_into().unwrap();
+//                         let dense_index_usize: usize = dense_index.try_into().unwrap();
+
+//                         debug_assert!(self.len > 0);
+//                         debug_assert!(self.len <= self.capacity);
+//                         debug_assert!(slot_index_usize <= self.capacity);
+//                         debug_assert!(dense_index_usize <= self.capacity);
+//                         debug_assert!(dense_index_usize < self.len);
+
+//                         let entities = self.entities.slice(self.len);
+//                         debug_assert!(entities.len() == self.len);
+//                         debug_assert!(entities[dense_index_usize].index() == entity.index());
+//                         debug_assert!(entities[dense_index_usize].version() == entity.version());
+
+//                         // SAFETY: We know that self.len > 0 from the early-out check above.
+//                         let last_dense_index = self.len - 1;
+//                         // SAFETY: We know the entity slice has a length of self.len.
+//                         let last_entity = *entities.get_unchecked(last_dense_index);
+//                         // SAFETY: We guarantee that stored entities point to valid slots.
+//                         let last_slot_index: usize = last_entity.index().try_into().unwrap();
+
+//                         // Perform the swap_remove on our data to drop the target entity.
+//                         // SAFETY: We guarantee that non-free slots point to valid dense data.
+//                         self.entities.swap_remove(dense_index_usize, self.len);
+//                         let result =
+//                             ($(self.[<d$i>].get_mut().swap_remove(dense_index_usize, self.len),)+);
+
+//                         // SAFETY: We guarantee this is allocated up to self.capacity.
+//                         let slots = &mut self.slots.slice_mut(self.capacity);
+
+//                         // NOTE: Order matters here to support the (target == last) case!
+//                         // Fix up the slot pointing to the last entity
+//                         slots
+//                             .get_unchecked_mut(last_slot_index) // SAFETY: See declaration.
+//                             .assign(dense_index);
+//                         // Return the target slot to the free list
+//                         slots
+//                             .get_unchecked_mut(slot_index_usize) // SAFETY: See declaration.
+//                             .release(self.free_head)
+//                             .expect("slot version overflow"); // TODO: Orphan this slot?
+
+//                         result
+//                     };
+
+//                     // TODO: We shouldn't add a slot to the free list if its version number
+//                     // is maxed out. It would be better to orphan that slot to avoid issues.
+
+//                     // Update the free list head
+//                     self.free_head = entity.index();
+//                     self.len -= 1;
+
+//                     Some(result)
+//                 }
+
+//                 /// Populates a slice struct with slices to our stored data.
+//                 #[inline(always)]
+//                 pub fn get_all_slices<'a, S: [<Slices$n>]<'a, A, $([<T$i>],)+>>(&'a mut self,) -> S {
+//                     unsafe {
+//                         // SAFETY: We guarantee that the storage is valid up to self.len.
+//                         S::new(
+//                             self.entities.slice(self.len),
+//                             $(self.[<d$i>].get_mut().slice_mut(self.len)),+
+//                         )
+//                     }
+//                 }
+
+//                 /// Gets a read-only slice of our currently stored entity handles.
+//                 #[inline(always)]
+//                 pub fn get_slice_entities(&self) -> &[Entity<A>] {
+//                     unsafe {
+//                         // SAFETY: We guarantee that the storage is valid up to self.len.
+//                         self.entities.slice(self.len)
+//                     }
+//                 }
+
+//                 $(
+//                     /// Gets a slice of the given component index.
+//                     #[inline(always)]
+//                     pub fn [<get_slice_$i>](&mut self) -> &[[<T$i>]] {
+//                         unsafe {
+//                             // SAFETY: We guarantee that the storage is valid up to self.len.
+//                             self.[<d$i>].get_mut().slice(self.len)
+//                         }
+//                     }
+
+//                     /// Gets a slice of the given component index.
+//                     #[inline(always)]
+//                     pub fn [<get_slice_mut_$i>](&mut self) -> &mut [[<T$i>]] {
+//                         unsafe {
+//                             // SAFETY: We guarantee that the storage is valid up to self.len.
+//                             self.[<d$i>].get_mut().slice_mut(self.len)
+//                         }
+//                     }
+
+//                     /// Borrows the slice of the given component index.
+//                     #[inline(always)]
+//                     pub fn [<borrow_slice_$i>](&self) -> Ref<[[<T$i>]]> {
+//                         Ref::map(self.[<d$i>].borrow(), |slice| unsafe {
+//                             // SAFETY: We guarantee that the storage is valid up to self.len.
+//                             slice.slice(self.len)
+//                         })
+//                     }
+
+//                     /// Mutably borrows the slice of the given component index.
+//                     #[inline(always)]
+//                     pub fn [<borrow_slice_mut_$i>](&self) -> RefMut<[[<T$i>]]> {
+//                         RefMut::map(self.[<d$i>].borrow_mut(), |slice| unsafe {
+//                             // SAFETY: We guarantee that the storage is valid up to self.len.
+//                             slice.slice_mut(self.len)
+//                         })
+//                     }
+//                 )+
+
+//                 /// Resolves the slot index and data index for a given entity.
+//                 /// Both indices are guaranteed to point to valid cells.
+//                 #[inline(always)]
+//                 fn resolve_slot(&self, entity: Entity<A>) -> Option<(u32, u32)> {
+//                     // Nothing to resolve if we have nothing stored
+//                     if self.len == 0 {
+//                         return None;
+//                     }
+
+//                     // Get the index into the slot array from the entity.
+//                     let slot_index = entity.index();
+
+//                     let slot = unsafe {
+//                         // NOTE: It's a little silly, but we don't actually know if this entity
+//                         // was created by this map, so we can't assume internal consistency here.
+//                         // We'll just have to take the small hit for bounds checking on the index.
+//                         if slot_index as usize >= self.capacity {
+//                             panic!("entity handle is invalid for this archetype");
+//                         }
+
+//                         // SAFETY: We guarantee that the array is allocated up to self.capacity.
+//                         let slots = self.slots.slice(self.capacity);
+//                         // SAFETY: We guarantee that the slot index is less than self.capacity.
+//                         slots.get_unchecked(slot_index as usize)
+//                     };
+
+//                     // NOTE: For similar reasons above, a crossed-wires entity handle from another
+//                     // world could miraculously have the correct version while pointing to a freed
+//                     // slot. This could cause some wacky memory access, so we need to allow slots
+//                     // to be explicitly identified as free or not. Again, this has a small cost.
+//                     if (slot.version() != entity.version()) || slot.is_free() {
+//                         return None; // Stale entity handle, fail the lookup
+//                     }
+
+//                     // Get the index into the dense array from the slot.
+//                     let dense_index = slot.index();
+
+//                     Some((slot_index, dense_index))
+//                 }
+//             }
+
+//             impl<A: Archetype, $([<T$i>],)+> Drop
+//                 for [<StorageDynamic$n>]<A, $([<T$i>],)+>
+//             {
+//                 #[inline(always)]
+//                 fn drop(&mut self) {
+//                     // SAFETY: We guarantee that the storage is valid up to self.len.
+//                     unsafe {
+//                         $(self.[<d$i>].get_mut().drop_to(self.len);)+
+//                         // We don't need to drop the other stuff since it's all trivial.
+//                     };
+//                 }
+//             }
+
+//             impl<A: Archetype, $([<T$i>],)+> Default
+//                 for [<StorageDynamic$n>]<A, $([<T$i>],)+>
+//             {
+//                 #[inline(always)]
+//                 fn default() -> Self {
+//                     [<StorageDynamic$n>]::new()
+//                 }
+//             }
+//         }
+//     };
+// }
+
+// // declare_storage_dynamic_n!(1, 0);
+// // declare_storage_dynamic_n!(2, 0, 1);
+// // declare_storage_dynamic_n!(3, 0, 1, 2);
+// declare_storage_dynamic_n!(4, 0, 1, 2, 3);
+// // declare_storage_dynamic_n!(5, 0, 1, 2, 3, 4);
+// // declare_storage_dynamic_n!(6, 0, 1, 2, 3, 4, 5);
+// // declare_storage_dynamic_n!(7, 0, 1, 2, 3, 4, 5, 6);
+// // declare_storage_dynamic_n!(8, 0, 1, 2, 3, 4, 5, 6, 7);
+// // declare_storage_dynamic_n!(9, 0, 1, 2, 3, 4, 5, 6, 7, 8);
+// // declare_storage_dynamic_n!(10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+// // declare_storage_dynamic_n!(11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+// // declare_storage_dynamic_n!(12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+// // declare_storage_dynamic_n!(13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+// // declare_storage_dynamic_n!(14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+// // declare_storage_dynamic_n!(15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+// // declare_storage_dynamic_n!(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+// /// Populates a free list in the range start..capacity with a fresh free list.
+// ///
+// /// # Safety
+// ///
+// /// It is up to the caller to guarantee the following:
+// /// - `array` has allocated at least `capacity` elements
+// /// - `start <= capacity`
+// /// - `capacity < u32::MAX`
+// #[inline(always)]
+// unsafe fn fill_free_list(array: &mut DataDynamic<Slot>, start: usize, capacity: usize) {
+//     unsafe {
+//         // SAFETY: The caller guarantees start <= capacity
+//         debug_checked_assume!(start <= capacity);
+//         debug_checked_assume!(capacity <= u32::MAX as usize);
+
+//         // NOTE: The last slot will point off the end of the free list.
+//         // In practice, we should never read this value anyway, since
+//         // we'd only ask to reserve when the dense list has room. However,
+//         // we may still want to check in the future if we decide to orphan
+//         // slots with overflowed versions (since we'd then have fewer slots
+//         // than dense list space). We'll need to revisit this logic if so.
+//         for i in start..capacity {
+//             array.write(i, Slot::new((i as u32) + 1));
+//         }
+//     }
+// }
+
+// pub struct DataDynamic<T>(NonNull<MaybeUninit<T>>);
+
+// impl<T> DataDynamic<T> {
+//     /// Creates a new empty data array. This does not allocate.
+//     pub fn new() -> Self {
+//         Self(NonNull::dangling())
+//     }
+
+//     /// Allocates a new data array with the given capacity, if any.
+//     ///
+//     ///
+//     /// # Panics
+//     ///
+//     /// This operation will panic if there is not enough memory to perform the new
+//     /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+//     pub fn with_capacity(new_capacity: usize) -> Self {
+//         if (mem::size_of::<T>() == 0) || (new_capacity == 0) {
+//             return Self(NonNull::dangling());
+//         }
+
+//         let new_lay = new_layout::<T>(new_capacity);
+
+//         debug_assert!(new_capacity > 0);
+//         debug_assert!(new_lay.size() > 0);
+
+//         unsafe { Self(resolve_ptr(alloc::alloc(new_lay), new_lay)) }
+//     }
+
+//     /// Allocates a new block of data for this array.
+//     ///
+//     /// If this array already has allocated memory, that memory will be leaked.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - `new_capacity > 0`
+//     ///
+//     /// # Panics
+//     ///
+//     /// This operation will panic if there is not enough memory to perform the new
+//     /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+//     pub unsafe fn alloc(&mut self, new_capacity: usize) {
+//         if mem::size_of::<T>() == 0 {
+//             return;
+//         }
+
+//         let new_layout = new_layout::<T>(new_capacity);
+
+//         debug_assert!(new_capacity > 0);
+//         debug_assert!(new_layout.size() > 0);
+
+//         unsafe {
+//             self.0 = resolve_ptr(
+//                 // SAFETY: We know that new_layout has a nonzero size.
+//                 alloc::alloc(new_layout),
+//                 new_layout,
+//             );
+//         }
+//     }
+
+//     /// Reallocates this array's old data block into a new data block.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - `new_capacity > 0`
+//     /// - `new_capacity >= old_capacity`
+//     /// - This array has exactly `old_capacity` elements allocated
+//     ///
+//     /// # Panics
+//     ///
+//     /// This operation will panic if there is not enough memory to perform the new
+//     /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+//     pub unsafe fn realloc(&mut self, old_capacity: usize, new_capacity: usize) {
+//         if mem::size_of::<T>() == 0 {
+//             return;
+//         }
+
+//         if old_capacity == 0 {
+//             // SAFETY: The caller guarantees that new_capacity > 0.
+//             unsafe { self.alloc(new_capacity) };
+//             return;
+//         }
+
+//         let old_ptr = self.0.as_ptr() as *mut u8;
+//         let new_layout = new_layout::<T>(new_capacity);
+//         let old_layout = Layout::array::<T>(old_capacity).unwrap();
+
+//         debug_assert!(new_capacity > 0);
+//         debug_assert!(old_capacity > 0);
+//         debug_assert!(new_capacity >= old_capacity);
+//         debug_assert!(new_layout.size() > 0);
+//         debug_assert!(old_layout.size() > 0);
+//         debug_assert!(old_ptr.is_null() == false);
+
+//         unsafe {
+//             self.0 = resolve_ptr(
+//                 // SAFETY: We know that both layouts have a nonzero size.
+//                 alloc::realloc(old_ptr, old_layout, new_layout.size()),
+//                 new_layout,
+//             );
+//         }
+//     }
+
+//     /// Deallocates this array's data block.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - This array has exactly `old_capacity` elements allocated
+//     pub unsafe fn dealloc(&mut self, old_capacity: usize) {
+//         if mem::size_of::<T>() == 0 {
+//             return;
+//         }
+
+//         if old_capacity == 0 {
+//             return;
+//         }
+
+//         let old_layout = Layout::array::<T>(old_capacity).unwrap();
+
+//         debug_assert!(old_capacity > 0);
+//         debug_assert!(old_layout.size() > 0);
+
+//         unsafe {
+//             // SAFETY: We know that old_layout has a nonzero size
+//             alloc::dealloc(self.0.as_ptr() as *mut u8, old_layout);
+//             self.0 = NonNull::dangling();
+//         }
+//     }
+
+//     /// Writes an element to the given index.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - This pointer has allocated at least `index` elements
+//     /// - The element at `index` is not currently initialized
+//     #[inline(always)]
+//     unsafe fn write(&mut self, index: usize, val: T) {
+//         unsafe {
+//             // SAFETY: The caller guarantees that this slot is allocated and uninitialized.
+//             (*self.0.as_ptr().add(index)).write(val);
+//         }
+//     }
+
+//     /// Gets a slice for the range `0..len`.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - This pointer has allocated at least `len` elements
+//     /// - All elements the range `0..len` are initialized
+//     #[inline(always)]
+//     unsafe fn slice(&self, len: usize) -> &[T] {
+//         // SAFETY: Casting `slice` to a `*const [T]` is safe since the caller guarantees that
+//         // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
+//         // The pointer obtained is valid since it refers to memory owned by `slice` which is a
+//         // reference and thus guaranteed to be valid for reads.
+//         // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#972
+//         unsafe { slice::from_raw_parts(self.0.as_ptr() as *const T, len) }
+//     }
+
+//     /// Gets a mutable slice for the range `0..len`.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - This pointer has allocated at least `len` elements
+//     /// - All elements the range `0..len` are valid data
+//     #[inline(always)]
+//     unsafe fn slice_mut(&mut self, len: usize) -> &mut [T] {
+//         // SAFETY: Similar to safety notes for `assume_init_slice`, but we have a
+//         // mutable reference which is also guaranteed to be valid for writes.
+//         // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#994
+//         unsafe { slice::from_raw_parts_mut(self.0.as_ptr() as *mut T, len) }
+//     }
+
+//     /// Drops the element at `index` and replaces it with the last element in `0..len`.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - This pointer has allocated at least `len` elements
+//     /// - All elements the range `0..len` are initialized
+//     /// - `len > 0`
+//     /// - `index < len`
+//     #[inline(always)]
+//     unsafe fn swap_remove(&mut self, index: usize, len: usize) -> T {
+//         unsafe {
+//             // SAFETY: These are all guaranteed by the caller and stated above.
+//             debug_checked_assume!(len > 0);
+//             debug_checked_assume!(index < len);
+
+//             // SAFETY: The caller is guaranteeing that the element at index, and
+//             // the element at len - 1 are both valid. With this guarantee we can
+//             // safely take the element at index. We then perform a direct pointer
+//             // copy (we can't assume nonoverlapping here!) from the last element
+//             // to the one at index. This moves the data, making the data at index
+//             // initialized to the data at last, and the data at last effectively
+//             // uninitialized (though bitwise identical to the data at index).
+//             let last = len - 1;
+//             let array_ptr = self.0.as_ptr();
+//             let result = ptr::read(array_ptr.add(index)).assume_init();
+//             ptr::copy(array_ptr.add(last), array_ptr.add(index), 1);
+//             *array_ptr.add(last) = MaybeUninit::uninit(); // Hint for Miri
+//             result
+//         }
+//     }
+
+//     /// Drops all elements in the range `0..len`.
+//     ///
+//     /// # Safety
+//     ///
+//     /// It is up to the caller to guarantee the following:
+//     /// - All elements in the range `0..len` are initialized
+//     /// - `len <= N`
+//     #[inline(always)]
+//     unsafe fn drop_to(&mut self, len: usize) {
+//         unsafe {
+//             for i in 0..len {
+//                 let i_ptr = self.0.as_ptr().add(i);
+//                 // SAFETY: The caller guarantees this element is valid.
+//                 ptr::drop_in_place(i_ptr as *mut T);
+//                 ptr::write(i_ptr, MaybeUninit::uninit()); // Hint for Miri
+//             }
+//         };
+//     }
+// }
+
+// #[inline(always)]
+// fn new_layout<T>(capacity: usize) -> Layout {
+//     let layout = Layout::array::<T>(capacity).unwrap();
+//     assert!(layout.size() <= isize::MAX as usize, "allocation too large");
+//     layout
+// }
+
+// #[inline(always)]
+// fn resolve_ptr<T>(ptr: *mut u8, layout: Layout) -> NonNull<T> {
+//     match NonNull::new(ptr as *mut T) {
+//         Some(p) => p,
+//         None => alloc::handle_alloc_error(layout),
+//     }
+// }

--- a/src/archetype/storage_dynamic.rs
+++ b/src/archetype/storage_dynamic.rs
@@ -1,2 +1,621 @@
 // TODO: Allow users to specify `dyn` as the capacity argument for archetypes.
 // Archetypes specified in this way will be backed by Vec-like dynamic storage.
+
+use std::alloc::{self, Layout};
+use std::array;
+use std::cell::{Ref, RefCell, RefMut};
+use std::mem::{self, MaybeUninit};
+use std::ptr::{self, NonNull};
+use std::slice;
+
+use paste::paste;
+
+use crate::archetype::slices::*;
+use crate::archetype::slot::Slot;
+use crate::entity::{Entity, EntityIndex, MAX_ARCHETYPE_CAPACITY};
+use crate::traits::Archetype;
+use crate::util::{debug_checked_assume, num_assert_leq, num_assert_lt};
+
+macro_rules! declare_storage_dynamic_n {
+    ($n:literal, $($i:literal),+) => {
+        paste! {
+            pub struct [<StorageDynamic$n>]<A: Archetype, $([<T$i>],)+> {
+                len: usize,
+                capacity: usize,
+                free_head: u32,
+                slots: DataDynamic<Slot>, // Sparse
+                // No RefCell here since we never grant mutable access externally
+                entities: DataDynamic<Entity<A>>,
+                $([<d$i>]: RefCell<DataDynamic<[<T$i>]>>,)+
+            }
+
+            impl<A: Archetype, $([<T$i>],)+> [<StorageDynamic$n>]<A, $([<T$i>],)+>
+            {
+                #[inline(always)]
+                pub fn new() -> Self {
+                    // We assume in a lot of places that u32 can trivially convert to usize
+                    num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
+                    let slots = DataDynamic::new(); // Don't need to populate
+
+                    Self {
+                        len: 0,
+                        capacity: 0,
+                        free_head: 0,
+                        slots,
+                        entities: DataDynamic::new(),
+                        $([<d$i>]: RefCell::new(DataDynamic::new()),)+
+                    }
+                }
+
+                #[inline(always)]
+                pub fn with_capacity(capacity: usize) -> Self {
+                    if (capacity > MAX_ARCHETYPE_CAPACITY as usize) {
+                        panic!("capacity may not exceed {}", MAX_ARCHETYPE_CAPACITY);
+                    }
+
+                    // We assume in a lot of places that u32 can trivially convert to usize
+                    num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
+                    let mut slots = DataDynamic::with_capacity(capacity);
+                    // SAFETY: We guarantee the free list is allocated to capacity
+                    unsafe { fill_free_list(&mut slots, 0, capacity) };
+
+                    Self {
+                        len: 0,
+                        capacity: 0,
+                        free_head: 0,
+                        slots,
+                        entities: DataDynamic::with_capacity(capacity),
+                        $([<d$i>]: RefCell::new(DataDynamic::with_capacity(capacity)),)+
+                    }
+                }
+
+                #[inline(always)]
+                pub const fn len(&self) -> usize {
+                    self.len
+                }
+
+                #[inline(always)]
+                pub const fn is_empty(&self) -> bool {
+                    self.len == 0
+                }
+
+                #[inline(always)]
+                pub const fn capacity(&self) -> usize {
+                    self.capacity
+                }
+
+                // /// Reserves a slot in the map pointing to the given dense index.
+                // /// Returns an entity handle if successful, or None if we're full.
+                // #[inline(always)]
+                // pub fn try_push(&mut self, data: ($([<T$i>],)+)) -> Option<Entity<A>> {
+                //     if self.len >= N {
+                //         return None;
+                //     }
+
+                //     // We know that self.len < N, and N <= u32::MAX
+                //     let dense_index: u32 = self.len as u32;
+                //     let slot_index: u32 = self.free_head;
+
+                //     // This means we're at the end of the free list
+                //     if (slot_index as usize) >= N {
+                //         return None;
+                //     }
+
+                //     unsafe {
+                //         debug_assert!((slot_index as usize) < N);
+                //         debug_assert!(slot_index < MAX_ARCHETYPE_CAPACITY);
+
+                //         // SAFETY: We know that slot_index < N
+                //         let slot = self.slots.get_unchecked_mut(slot_index as usize);
+                //         // SAFETY: We know that slot_index < MAX_ARCHETYPE_CAPACITY
+                //         let entity_index = EntityIndex::new_unchecked(slot_index);
+
+                //         // NOTE: Do not change the following order of operations!
+                //         debug_assert!(slot.is_free());
+                //         self.free_head = slot.index();
+                //         slot.assign(dense_index);
+                //         let entity = Entity::new(entity_index, slot.version());
+                //         let index = self.len;
+                //         self.len += 1;
+
+                //         // SAFETY: We can't overflow because self.len < N.
+                //         debug_checked_assume!(index < self.len);
+
+                //         // SAFETY: We know that index < N and points to an empty cell.
+                //         //////////self.entities.slice_mut(self.len)[index] = entity;
+                //         //////////$(self.[<d$i>].get_mut().slice_mut(self.len)[index] = data.$i;)+
+
+                //         Some(entity)
+                //     }
+                // }
+
+                // /// Resolves an entity to an index in the storage data slices.
+                // /// This index is guaranteed to be in bounds and point to valid data.
+                // #[inline(always)]
+                // pub fn resolve(&self, entity: Entity<A>) -> Option<usize> {
+                //     let (_, dense_index) = match self.resolve_slot(entity) {
+                //         None => { return None; }
+                //         Some(found) => found,
+                //     };
+
+                //     let dense_index = dense_index.try_into().unwrap();
+
+                //     unsafe {
+                //         // SAFETY: resolve_slot guarantees this index is valid.
+                //         // We assume this to help avoid bounds checks later on.
+                //         debug_checked_assume!(dense_index < self.len);
+                //     }
+
+                //     Some(dense_index)
+                // }
+
+                // /// Removes the given entity from storage if it exists there.
+                // /// Returns the removed entity's components, if any.
+                // #[inline(always)]
+                // pub fn remove(&mut self, entity: Entity<A>) -> Option<($([<T$i>],)*)> {
+                //     let (slot_index, dense_index) = match self.resolve_slot(entity) {
+                //         None => { return None; }
+                //         Some(found) => found,
+                //     };
+
+                //     let result = unsafe {
+                //         // SAFETY: These are guaranteed by resolve_slot to be in range.
+                //         let slot_index_usize: usize = slot_index.try_into().unwrap();
+                //         let dense_index_usize: usize = dense_index.try_into().unwrap();
+
+                //         debug_assert!(self.len > 0);
+                //         debug_assert!(self.len <= N);
+                //         debug_assert!(slot_index_usize <= N);
+                //         debug_assert!(dense_index_usize <= N);
+                //         debug_assert!(dense_index_usize < self.len);
+
+                //         let entities = self.entities.slice(self.len);
+                //         debug_assert!(entities.len() == self.len);
+                //         debug_assert!(entities[dense_index_usize].index() == entity.index());
+                //         debug_assert!(entities[dense_index_usize].version() == entity.version());
+
+                //         // SAFETY: We know that self.len > 0 from the early-out check above.
+                //         let last_dense_index = self.len - 1;
+                //         // SAFETY: We know the entity slice has a length of self.len.
+                //         let last_entity = *entities.get_unchecked(last_dense_index);
+                //         // SAFETY: We guarantee that stored entities point to valid slots.
+                //         let last_slot_index: usize = last_entity.index().try_into().unwrap();
+
+                //         // Perform the swap_remove on our data to drop the target entity.
+                //         // SAFETY: We guarantee that non-free slots point to valid dense data.
+                //         self.entities.swap_remove(dense_index_usize, self.len);
+                //         let result =
+                //             ($(self.[<d$i>].get_mut().swap_remove(dense_index_usize, self.len),)+);
+
+                //         // NOTE: Order matters here to support the (target == last) case!
+                //         // Fix up the slot pointing to the last entity
+                //         self.slots
+                //             .get_unchecked_mut(last_slot_index) // SAFETY: See declaration.
+                //             .assign(dense_index);
+                //         // Return the target slot to the free list
+                //         self.slots
+                //             .get_unchecked_mut(slot_index_usize) // SAFETY: See declaration.
+                //             .release(self.free_head)
+                //             .expect("slot version overflow"); // TODO: Orphan this slot?
+
+                //         result
+                //     };
+
+                //     // TODO: We shouldn't add a slot to the free list if its version number
+                //     // is maxed out. It would be better to orphan that slot to avoid issues.
+
+                //     // Update the free list head
+                //     self.free_head = entity.index();
+                //     self.len -= 1;
+
+                //     Some(result)
+                // }
+
+                /// Populates a slice struct with slices to our stored data.
+                #[inline(always)]
+                pub fn get_all_slices<'a, S: [<Slices$n>]<'a, A, $([<T$i>],)+>>(&'a mut self,) -> S {
+                    unsafe {
+                        // SAFETY: We guarantee that the storage is valid up to self.len.
+                        S::new(
+                            self.entities.slice(self.len),
+                            $(self.[<d$i>].get_mut().slice_mut(self.len)),+
+                        )
+                    }
+                }
+
+                /// Gets a read-only slice of our currently stored entity handles.
+                #[inline(always)]
+                pub fn get_slice_entities(&self) -> &[Entity<A>] {
+                    unsafe {
+                        // SAFETY: We guarantee that the storage is valid up to self.len.
+                        self.entities.slice(self.len)
+                    }
+                }
+
+                $(
+                    /// Gets a slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<get_slice_$i>](&mut self) -> &[[<T$i>]] {
+                        unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            self.[<d$i>].get_mut().slice(self.len)
+                        }
+                    }
+
+                    /// Gets a slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<get_slice_mut_$i>](&mut self) -> &mut [[<T$i>]] {
+                        unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            self.[<d$i>].get_mut().slice_mut(self.len)
+                        }
+                    }
+
+                    /// Borrows the slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<borrow_slice_$i>](&self) -> Ref<[[<T$i>]]> {
+                        Ref::map(self.[<d$i>].borrow(), |slice| unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            slice.slice(self.len)
+                        })
+                    }
+
+                    /// Mutably borrows the slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<borrow_slice_mut_$i>](&self) -> RefMut<[[<T$i>]]> {
+                        RefMut::map(self.[<d$i>].borrow_mut(), |slice| unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            slice.slice_mut(self.len)
+                        })
+                    }
+                )+
+
+                /// Resolves the slot index and data index for a given entity.
+                /// Both indices are guaranteed to point to valid cells.
+                #[inline(always)]
+                fn resolve_slot(&self, entity: Entity<A>) -> Option<(u32, u32)> {
+                    // Nothing to resolve if we have nothing stored
+                    if self.len == 0 {
+                        return None;
+                    }
+
+                    // Get the index into the slot array from the entity.
+                    let slot_index = entity.index();
+
+                    let slot = unsafe {
+                        // NOTE: It's a little silly, but we don't actually know if this entity
+                        // was created by this map, so we can't assume internal consistency here.
+                        // We'll just have to take the small hit for bounds checking on the index.
+                        if slot_index as usize >= self.capacity {
+                            panic!("entity handle is invalid for this archetype");
+                        }
+
+                        // SAFETY: We guarantee that the array is allocated up to self.capacity.
+                        // SAFETY: We guarantee that the slot index is less than self.capacity.
+                        self.slots.slice(self.capacity).get_unchecked(slot_index as usize)
+                    };
+
+                    if (slot.version() != entity.version()) || slot.is_free() {
+                        return None; // Stale entity handle, fail the lookup
+                    }
+
+                    // Get the index into the dense array from the slot.
+                    let dense_index = slot.index();
+
+                    Some((slot_index, dense_index))
+                }
+            }
+
+            impl<A: Archetype, $([<T$i>],)+> Drop
+                for [<StorageDynamic$n>]<A, $([<T$i>],)+>
+            {
+                #[inline(always)]
+                fn drop(&mut self) {
+                    // SAFETY: We guarantee that the storage is valid up to self.len.
+                    unsafe {
+                        $(self.[<d$i>].get_mut().drop_to(self.len);)+
+                        // We don't need to drop the other stuff since it's all trivial.
+                    };
+                }
+            }
+
+            impl<A: Archetype, $([<T$i>],)+> Default
+                for [<StorageDynamic$n>]<A, $([<T$i>],)+>
+            {
+                #[inline(always)]
+                fn default() -> Self {
+                    [<StorageDynamic$n>]::new()
+                }
+            }
+        }
+    };
+}
+
+// declare_storage_dynamic_n!(1, 0);
+// declare_storage_dynamic_n!(2, 0, 1);
+// declare_storage_dynamic_n!(3, 0, 1, 2);
+declare_storage_dynamic_n!(4, 0, 1, 2, 3);
+// declare_storage_dynamic_n!(5, 0, 1, 2, 3, 4);
+// declare_storage_dynamic_n!(6, 0, 1, 2, 3, 4, 5);
+// declare_storage_dynamic_n!(7, 0, 1, 2, 3, 4, 5, 6);
+// declare_storage_dynamic_n!(8, 0, 1, 2, 3, 4, 5, 6, 7);
+// declare_storage_dynamic_n!(9, 0, 1, 2, 3, 4, 5, 6, 7, 8);
+// declare_storage_dynamic_n!(10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+// declare_storage_dynamic_n!(11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+// declare_storage_dynamic_n!(12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+// declare_storage_dynamic_n!(13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+// declare_storage_dynamic_n!(14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+// declare_storage_dynamic_n!(15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+// declare_storage_dynamic_n!(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+/// Populates a free list in the range start..capacity with a fresh free list.
+///
+/// # Safety
+///
+/// It is up to the caller to guarantee the following:
+/// - `array` has allocated at least `capacity` elements
+/// - `start <= capacity`
+/// - `capacity < u32::MAX`
+#[inline(always)]
+unsafe fn fill_free_list(array: &mut DataDynamic<Slot>, start: usize, capacity: usize) {
+    unsafe {
+        // SAFETY: The caller guarantees start <= capacity
+        debug_checked_assume!(start <= capacity);
+        debug_checked_assume!(capacity <= u32::MAX as usize);
+
+        // NOTE: The last slot will point off the end of the free list.
+        // In practice, we should never read this value anyway, since
+        // we'd only ask to reserve when the dense list has room. However,
+        // we may still want to check in the future if we decide to orphan
+        // slots with overflowed versions (since we'd then have fewer slots
+        // than dense list space). We'll need to revisit this logic if so.
+        for i in start..capacity {
+            array.write(i, Slot::new((i as u32) + 1));
+        }
+    }
+}
+
+pub struct DataDynamic<T>(NonNull<MaybeUninit<T>>);
+
+impl<T> DataDynamic<T> {
+    /// Creates a new empty data array. This does not allocate.
+    pub fn new() -> Self {
+        Self(NonNull::dangling())
+    }
+
+    /// Allocates a new data array with the given capacity, if any.
+    ///
+    ///
+    /// # Panics
+    ///
+    /// This operation will panic if there is not enough memory to perform the new
+    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+    pub fn with_capacity(new_capacity: usize) -> Self {
+        if (mem::size_of::<T>() == 0) || (new_capacity == 0) {
+            return Self(NonNull::dangling());
+        }
+
+        let new_lay = new_layout::<T>(new_capacity);
+
+        debug_assert!(new_capacity > 0);
+        debug_assert!(new_lay.size() > 0);
+
+        unsafe { Self(resolve_ptr(alloc::alloc(new_lay), new_lay)) }
+    }
+
+    /// Allocates a new block of data for this array.
+    ///
+    /// If this array already has allocated memory, that memory will be leaked.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - `new_capacity > 0`
+    ///
+    /// # Panics
+    ///
+    /// This operation will panic if there is not enough memory to perform the new
+    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+    pub unsafe fn alloc(&mut self, new_capacity: usize) {
+        if mem::size_of::<T>() == 0 {
+            return;
+        }
+
+        let new_layout = new_layout::<T>(new_capacity);
+
+        debug_assert!(new_capacity > 0);
+        debug_assert!(new_layout.size() > 0);
+
+        unsafe {
+            self.0 = resolve_ptr(
+                // SAFETY: We know that new_layout has a nonzero size.
+                alloc::alloc(new_layout),
+                new_layout,
+            );
+        }
+    }
+
+    /// Reallocates this array's old data block into a new data block.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - `new_capacity > 0`
+    /// - `new_capacity >= old_capacity`
+    /// - This array has exactly `old_capacity` elements allocated
+    ///
+    /// # Panics
+    ///
+    /// This operation will panic if there is not enough memory to perform the new
+    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+    pub unsafe fn realloc(&mut self, old_capacity: usize, new_capacity: usize) {
+        if mem::size_of::<T>() == 0 {
+            return;
+        }
+
+        if old_capacity == 0 {
+            // SAFETY: The caller guarantees that new_capacity > 0.
+            unsafe { self.alloc(new_capacity) };
+            return;
+        }
+
+        let old_ptr = self.0.as_ptr() as *mut u8;
+        let new_layout = new_layout::<T>(new_capacity);
+        let old_layout = Layout::array::<T>(old_capacity).unwrap();
+
+        debug_assert!(new_capacity > 0);
+        debug_assert!(old_capacity > 0);
+        debug_assert!(new_capacity >= old_capacity);
+        debug_assert!(new_layout.size() > 0);
+        debug_assert!(old_layout.size() > 0);
+        debug_assert!(old_ptr.is_null() == false);
+
+        unsafe {
+            self.0 = resolve_ptr(
+                // SAFETY: We know that both layouts have a nonzero size.
+                alloc::realloc(old_ptr, old_layout, new_layout.size()),
+                new_layout,
+            );
+        }
+    }
+
+    /// Deallocates this array's data block.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This array has exactly `old_capacity` elements allocated
+    pub unsafe fn dealloc(&mut self, old_capacity: usize) {
+        if mem::size_of::<T>() == 0 {
+            return;
+        }
+
+        if old_capacity == 0 {
+            return;
+        }
+
+        let old_layout = Layout::array::<T>(old_capacity).unwrap();
+
+        debug_assert!(old_capacity > 0);
+        debug_assert!(old_layout.size() > 0);
+
+        unsafe {
+            // SAFETY: We know that old_layout has a nonzero size
+            alloc::dealloc(self.0.as_ptr() as *mut u8, old_layout);
+            self.0 = NonNull::dangling();
+        }
+    }
+
+    /// Writes an element to the given index.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `index` elements
+    /// - The element at `index` is not currently initialized
+    #[inline(always)]
+    unsafe fn write(&mut self, index: usize, val: T) {
+        unsafe {
+            // SAFETY: The caller guarantees that this slot is allocated and uninitialized.
+            (*self.0.as_ptr().add(index)).write(val);
+        }
+    }
+
+    /// Gets a slice for the range `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `len` elements
+    /// - All elements the range `0..len` are initialized
+    #[inline(always)]
+    unsafe fn slice(&self, len: usize) -> &[T] {
+        // SAFETY: Casting `slice` to a `*const [T]` is safe since the caller guarantees that
+        // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
+        // The pointer obtained is valid since it refers to memory owned by `slice` which is a
+        // reference and thus guaranteed to be valid for reads.
+        // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#972
+        unsafe { slice::from_raw_parts(self.0.as_ptr() as *const T, len) }
+    }
+
+    /// Gets a mutable slice for the range `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `len` elements
+    /// - All elements the range `0..len` are valid data
+    #[inline(always)]
+    unsafe fn slice_mut(&mut self, len: usize) -> &mut [T] {
+        // SAFETY: Similar to safety notes for `assume_init_slice`, but we have a
+        // mutable reference which is also guaranteed to be valid for writes.
+        // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#994
+        unsafe { slice::from_raw_parts_mut(self.0.as_ptr() as *mut T, len) }
+    }
+
+    /// Drops the element at `index` and replaces it with the last element in `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `len` elements
+    /// - All elements the range `0..len` are initialized
+    /// - `len > 0`
+    /// - `index < len`
+    #[inline(always)]
+    unsafe fn swap_remove(&mut self, index: usize, len: usize) -> T {
+        unsafe {
+            // SAFETY: These are all guaranteed by the caller and stated above.
+            debug_checked_assume!(len > 0);
+            debug_checked_assume!(index < len);
+
+            // SAFETY: The caller is guaranteeing that the element at index, and
+            // the element at len - 1 are both valid. With this guarantee we can
+            // safely take the element at index. We then perform a direct pointer
+            // copy (we can't assume nonoverlapping here!) from the last element
+            // to the one at index. This moves the data, making the data at index
+            // initialized to the data at last, and the data at last effectively
+            // uninitialized (though bitwise identical to the data at index).
+            let last = len - 1;
+            let array_ptr = self.0.as_ptr();
+            let result = ptr::read(array_ptr.add(index)).assume_init();
+            ptr::copy(array_ptr.add(last), array_ptr.add(index), 1);
+            *array_ptr.add(last) = MaybeUninit::uninit(); // Hint for Miri
+            result
+        }
+    }
+
+    /// Drops all elements in the range `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - All elements in the range `0..len` are initialized
+    /// - `len <= N`
+    #[inline(always)]
+    unsafe fn drop_to(&mut self, len: usize) {
+        unsafe {
+            for i in 0..len {
+                let i_ptr = self.0.as_ptr().add(i);
+                // SAFETY: The caller guarantees this element is valid.
+                ptr::drop_in_place(i_ptr as *mut T);
+                ptr::write(i_ptr, MaybeUninit::uninit()); // Hint for Miri
+            }
+        };
+    }
+}
+
+#[inline(always)]
+fn new_layout<T>(capacity: usize) -> Layout {
+    let layout = Layout::array::<T>(capacity).unwrap();
+    assert!(layout.size() <= isize::MAX as usize, "allocation too large");
+    layout
+}
+
+#[inline(always)]
+fn resolve_ptr<T>(ptr: *mut u8, layout: Layout) -> NonNull<T> {
+    match NonNull::new(ptr as *mut T) {
+        Some(p) => p,
+        None => alloc::handle_alloc_error(layout),
+    }
+}

--- a/src/archetype/storage_dynamic.rs
+++ b/src/archetype/storage_dynamic.rs
@@ -1,630 +1,613 @@
-// // TODO: Allow users to specify `dyn` as the capacity argument for archetypes.
-// // Archetypes specified in this way will be backed by Vec-like dynamic storage.
-
-// use std::alloc::{self, Layout};
-// use std::array;
-// use std::cell::{Ref, RefCell, RefMut};
-// use std::mem::{self, MaybeUninit};
-// use std::ptr::{self, NonNull};
-// use std::slice;
-
-// use paste::paste;
-
-// use crate::archetype::slices::*;
-// use crate::archetype::slot::Slot;
-// use crate::entity::Entity;
-// use crate::index::{DataIndex, MAX_DATA_CAPACITY};
-// use crate::traits::Archetype;
-// use crate::util::{debug_checked_assume, num_assert_leq, num_assert_lt};
-
-// macro_rules! declare_storage_dynamic_n {
-//     ($n:literal, $($i:literal),+) => {
-//         paste! {
-//             pub struct [<StorageDynamic$n>]<A: Archetype, $([<T$i>],)+> {
-//                 len: usize,
-//                 capacity: usize,
-//                 free_head: u32,
-//                 slots: DataDynamic<Slot>, // Sparse
-//                 // No RefCell here since we never grant mutable access externally
-//                 entities: DataDynamic<Entity<A>>,
-//                 $([<d$i>]: RefCell<DataDynamic<[<T$i>]>>,)+
-//             }
-
-//             impl<A: Archetype, $([<T$i>],)+> [<StorageDynamic$n>]<A, $([<T$i>],)+>
-//             {
-//                 #[inline(always)]
-//                 pub fn new() -> Self {
-//                     // We assume in a lot of places that u32 can trivially convert to usize
-//                     num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
-//                     let slots = DataDynamic::new(); // Don't need to populate
-
-//                     Self {
-//                         len: 0,
-//                         capacity: 0,
-//                         free_head: 0,
-//                         slots,
-//                         entities: DataDynamic::new(),
-//                         $([<d$i>]: RefCell::new(DataDynamic::new()),)+
-//                     }
-//                 }
-
-//                 #[inline(always)]
-//                 pub fn with_capacity(capacity: usize) -> Self {
-//                     if (capacity > MAX_DATA_CAPACITY as usize) {
-//                         panic!("capacity may not exceed {}", MAX_DATA_CAPACITY);
-//                     }
-
-//                     // We assume in a lot of places that u32 can trivially convert to usize
-//                     num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
-//                     let mut slots = DataDynamic::with_capacity(capacity);
-//                     // SAFETY: We guarantee the free list is allocated to capacity
-//                     unsafe { fill_free_list(&mut slots, 0, capacity) };
-
-//                     Self {
-//                         len: 0,
-//                         capacity: 0,
-//                         free_head: 0,
-//                         slots,
-//                         entities: DataDynamic::with_capacity(capacity),
-//                         $([<d$i>]: RefCell::new(DataDynamic::with_capacity(capacity)),)+
-//                     }
-//                 }
-
-//                 #[inline(always)]
-//                 pub const fn len(&self) -> usize {
-//                     self.len
-//                 }
-
-//                 #[inline(always)]
-//                 pub const fn is_empty(&self) -> bool {
-//                     self.len == 0
-//                 }
-
-//                 #[inline(always)]
-//                 pub const fn capacity(&self) -> usize {
-//                     self.capacity
-//                 }
-
-//                 // /// Reserves a slot in the map pointing to the given dense index.
-//                 // /// Returns an entity handle if successful, or None if we're full.
-//                 // #[inline(always)]
-//                 // pub fn try_push(&mut self, data: ($([<T$i>],)+)) -> Option<Entity<A>> {
-//                 //     if self.len >= N {
-//                 //         return None;
-//                 //     }
-
-//                 //     // We know that self.len < N, and N <= u32::MAX
-//                 //     let dense_index: u32 = self.len as u32;
-//                 //     let slot_index: u32 = self.free_head;
-
-//                 //     // This means we're at the end of the free list
-//                 //     if (slot_index as usize) >= N {
-//                 //         return None;
-//                 //     }
-
-//                 //     unsafe {
-//                 //         debug_assert!((slot_index as usize) < N);
-//                 //         debug_assert!(slot_index < MAX_DATA_CAPACITY);
-
-//                 //         // SAFETY: We know that slot_index < N
-//                 //         let slot = self.slots.get_unchecked_mut(slot_index as usize);
-//                 //         // SAFETY: We know that slot_index < MAX_DATA_CAPACITY
-//                 //         let entity_index = EntityIndex::new_unchecked(slot_index);
-
-//                 //         // NOTE: Do not change the following order of operations!
-//                 //         debug_assert!(slot.is_free());
-//                 //         self.free_head = slot.index();
-//                 //         slot.assign(dense_index);
-//                 //         let entity = Entity::new(entity_index, slot.version());
-//                 //         let index = self.len;
-//                 //         self.len += 1;
-
-//                 //         // SAFETY: We can't overflow because self.len < N.
-//                 //         debug_checked_assume!(index < self.len);
-
-//                 //         // SAFETY: We know that index < N and points to an empty cell.
-//                 //         //////////self.entities.slice_mut(self.len)[index] = entity;
-//                 //         //////////$(self.[<d$i>].get_mut().slice_mut(self.len)[index] = data.$i;)+
-
-//                 //         Some(entity)
-//                 //     }
-//                 // }
-
-//                 /// Resolves an entity to an index in the storage data slices.
-//                 /// This index is guaranteed to be in bounds and point to valid data.
-//                 #[inline(always)]
-//                 pub fn resolve(&self, entity: Entity<A>) -> Option<usize> {
-//                     let (_, dense_index) = match self.resolve_slot(entity) {
-//                         None => { return None; }
-//                         Some(found) => found,
-//                     };
-
-//                     let dense_index = dense_index.try_into().unwrap();
-
-//                     unsafe {
-//                         // SAFETY: resolve_slot guarantees this index is valid.
-//                         // We assume this to help avoid bounds checks later on.
-//                         debug_checked_assume!(dense_index < self.len);
-//                     }
-
-//                     Some(dense_index)
-//                 }
-
-//                 /// Removes the given entity from storage if it exists there.
-//                 /// Returns the removed entity's components, if any.
-//                 #[inline(always)]
-//                 pub fn remove(&mut self, entity: Entity<A>) -> Option<($([<T$i>],)*)> {
-//                     let (slot_index, dense_index) = match self.resolve_slot(entity) {
-//                         None => { return None; }
-//                         Some(found) => found,
-//                     };
-
-//                     let result = unsafe {
-//                         // SAFETY: These are guaranteed by resolve_slot to be in range.
-//                         let slot_index_usize: usize = slot_index.try_into().unwrap();
-//                         let dense_index_usize: usize = dense_index.try_into().unwrap();
-
-//                         debug_assert!(self.len > 0);
-//                         debug_assert!(self.len <= self.capacity);
-//                         debug_assert!(slot_index_usize <= self.capacity);
-//                         debug_assert!(dense_index_usize <= self.capacity);
-//                         debug_assert!(dense_index_usize < self.len);
-
-//                         let entities = self.entities.slice(self.len);
-//                         debug_assert!(entities.len() == self.len);
-//                         debug_assert!(entities[dense_index_usize].index() == entity.index());
-//                         debug_assert!(entities[dense_index_usize].version() == entity.version());
-
-//                         // SAFETY: We know that self.len > 0 from the early-out check above.
-//                         let last_dense_index = self.len - 1;
-//                         // SAFETY: We know the entity slice has a length of self.len.
-//                         let last_entity = *entities.get_unchecked(last_dense_index);
-//                         // SAFETY: We guarantee that stored entities point to valid slots.
-//                         let last_slot_index: usize = last_entity.index().try_into().unwrap();
-
-//                         // Perform the swap_remove on our data to drop the target entity.
-//                         // SAFETY: We guarantee that non-free slots point to valid dense data.
-//                         self.entities.swap_remove(dense_index_usize, self.len);
-//                         let result =
-//                             ($(self.[<d$i>].get_mut().swap_remove(dense_index_usize, self.len),)+);
-
-//                         // SAFETY: We guarantee this is allocated up to self.capacity.
-//                         let slots = &mut self.slots.slice_mut(self.capacity);
-
-//                         // NOTE: Order matters here to support the (target == last) case!
-//                         // Fix up the slot pointing to the last entity
-//                         slots
-//                             .get_unchecked_mut(last_slot_index) // SAFETY: See declaration.
-//                             .assign(dense_index);
-//                         // Return the target slot to the free list
-//                         slots
-//                             .get_unchecked_mut(slot_index_usize) // SAFETY: See declaration.
-//                             .release(self.free_head)
-//                             .expect("slot version overflow"); // TODO: Orphan this slot?
-
-//                         result
-//                     };
-
-//                     // TODO: We shouldn't add a slot to the free list if its version number
-//                     // is maxed out. It would be better to orphan that slot to avoid issues.
-
-//                     // Update the free list head
-//                     self.free_head = entity.index();
-//                     self.len -= 1;
-
-//                     Some(result)
-//                 }
-
-//                 /// Populates a slice struct with slices to our stored data.
-//                 #[inline(always)]
-//                 pub fn get_all_slices<'a, S: [<Slices$n>]<'a, A, $([<T$i>],)+>>(&'a mut self,) -> S {
-//                     unsafe {
-//                         // SAFETY: We guarantee that the storage is valid up to self.len.
-//                         S::new(
-//                             self.entities.slice(self.len),
-//                             $(self.[<d$i>].get_mut().slice_mut(self.len)),+
-//                         )
-//                     }
-//                 }
-
-//                 /// Gets a read-only slice of our currently stored entity handles.
-//                 #[inline(always)]
-//                 pub fn get_slice_entities(&self) -> &[Entity<A>] {
-//                     unsafe {
-//                         // SAFETY: We guarantee that the storage is valid up to self.len.
-//                         self.entities.slice(self.len)
-//                     }
-//                 }
-
-//                 $(
-//                     /// Gets a slice of the given component index.
-//                     #[inline(always)]
-//                     pub fn [<get_slice_$i>](&mut self) -> &[[<T$i>]] {
-//                         unsafe {
-//                             // SAFETY: We guarantee that the storage is valid up to self.len.
-//                             self.[<d$i>].get_mut().slice(self.len)
-//                         }
-//                     }
-
-//                     /// Gets a slice of the given component index.
-//                     #[inline(always)]
-//                     pub fn [<get_slice_mut_$i>](&mut self) -> &mut [[<T$i>]] {
-//                         unsafe {
-//                             // SAFETY: We guarantee that the storage is valid up to self.len.
-//                             self.[<d$i>].get_mut().slice_mut(self.len)
-//                         }
-//                     }
-
-//                     /// Borrows the slice of the given component index.
-//                     #[inline(always)]
-//                     pub fn [<borrow_slice_$i>](&self) -> Ref<[[<T$i>]]> {
-//                         Ref::map(self.[<d$i>].borrow(), |slice| unsafe {
-//                             // SAFETY: We guarantee that the storage is valid up to self.len.
-//                             slice.slice(self.len)
-//                         })
-//                     }
-
-//                     /// Mutably borrows the slice of the given component index.
-//                     #[inline(always)]
-//                     pub fn [<borrow_slice_mut_$i>](&self) -> RefMut<[[<T$i>]]> {
-//                         RefMut::map(self.[<d$i>].borrow_mut(), |slice| unsafe {
-//                             // SAFETY: We guarantee that the storage is valid up to self.len.
-//                             slice.slice_mut(self.len)
-//                         })
-//                     }
-//                 )+
-
-//                 /// Resolves the slot index and data index for a given entity.
-//                 /// Both indices are guaranteed to point to valid cells.
-//                 #[inline(always)]
-//                 fn resolve_slot(&self, entity: Entity<A>) -> Option<(u32, u32)> {
-//                     // Nothing to resolve if we have nothing stored
-//                     if self.len == 0 {
-//                         return None;
-//                     }
-
-//                     // Get the index into the slot array from the entity.
-//                     let slot_index = entity.index();
-
-//                     let slot = unsafe {
-//                         // NOTE: It's a little silly, but we don't actually know if this entity
-//                         // was created by this map, so we can't assume internal consistency here.
-//                         // We'll just have to take the small hit for bounds checking on the index.
-//                         if slot_index as usize >= self.capacity {
-//                             panic!("entity handle is invalid for this archetype");
-//                         }
-
-//                         // SAFETY: We guarantee that the array is allocated up to self.capacity.
-//                         let slots = self.slots.slice(self.capacity);
-//                         // SAFETY: We guarantee that the slot index is less than self.capacity.
-//                         slots.get_unchecked(slot_index as usize)
-//                     };
-
-//                     // NOTE: For similar reasons above, a crossed-wires entity handle from another
-//                     // world could miraculously have the correct version while pointing to a freed
-//                     // slot. This could cause some wacky memory access, so we need to allow slots
-//                     // to be explicitly identified as free or not. Again, this has a small cost.
-//                     if (slot.version() != entity.version()) || slot.is_free() {
-//                         return None; // Stale entity handle, fail the lookup
-//                     }
-
-//                     // Get the index into the dense array from the slot.
-//                     let dense_index = slot.index();
-
-//                     Some((slot_index, dense_index))
-//                 }
-//             }
-
-//             impl<A: Archetype, $([<T$i>],)+> Drop
-//                 for [<StorageDynamic$n>]<A, $([<T$i>],)+>
-//             {
-//                 #[inline(always)]
-//                 fn drop(&mut self) {
-//                     // SAFETY: We guarantee that the storage is valid up to self.len.
-//                     unsafe {
-//                         $(self.[<d$i>].get_mut().drop_to(self.len);)+
-//                         // We don't need to drop the other stuff since it's all trivial.
-//                     };
-//                 }
-//             }
-
-//             impl<A: Archetype, $([<T$i>],)+> Default
-//                 for [<StorageDynamic$n>]<A, $([<T$i>],)+>
-//             {
-//                 #[inline(always)]
-//                 fn default() -> Self {
-//                     [<StorageDynamic$n>]::new()
-//                 }
-//             }
-//         }
-//     };
-// }
-
-// // declare_storage_dynamic_n!(1, 0);
-// // declare_storage_dynamic_n!(2, 0, 1);
-// // declare_storage_dynamic_n!(3, 0, 1, 2);
-// declare_storage_dynamic_n!(4, 0, 1, 2, 3);
-// // declare_storage_dynamic_n!(5, 0, 1, 2, 3, 4);
-// // declare_storage_dynamic_n!(6, 0, 1, 2, 3, 4, 5);
-// // declare_storage_dynamic_n!(7, 0, 1, 2, 3, 4, 5, 6);
-// // declare_storage_dynamic_n!(8, 0, 1, 2, 3, 4, 5, 6, 7);
-// // declare_storage_dynamic_n!(9, 0, 1, 2, 3, 4, 5, 6, 7, 8);
-// // declare_storage_dynamic_n!(10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-// // declare_storage_dynamic_n!(11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-// // declare_storage_dynamic_n!(12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-// // declare_storage_dynamic_n!(13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-// // declare_storage_dynamic_n!(14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-// // declare_storage_dynamic_n!(15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-// // declare_storage_dynamic_n!(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-
-// /// Populates a free list in the range start..capacity with a fresh free list.
-// ///
-// /// # Safety
-// ///
-// /// It is up to the caller to guarantee the following:
-// /// - `array` has allocated at least `capacity` elements
-// /// - `start <= capacity`
-// /// - `capacity < u32::MAX`
-// #[inline(always)]
-// unsafe fn fill_free_list(array: &mut DataDynamic<Slot>, start: usize, capacity: usize) {
-//     unsafe {
-//         // SAFETY: The caller guarantees start <= capacity
-//         debug_checked_assume!(start <= capacity);
-//         debug_checked_assume!(capacity <= u32::MAX as usize);
-
-//         // NOTE: The last slot will point off the end of the free list.
-//         // In practice, we should never read this value anyway, since
-//         // we'd only ask to reserve when the dense list has room. However,
-//         // we may still want to check in the future if we decide to orphan
-//         // slots with overflowed versions (since we'd then have fewer slots
-//         // than dense list space). We'll need to revisit this logic if so.
-//         for i in start..capacity {
-//             array.write(i, Slot::new((i as u32) + 1));
-//         }
-//     }
-// }
-
-// pub struct DataDynamic<T>(NonNull<MaybeUninit<T>>);
-
-// impl<T> DataDynamic<T> {
-//     /// Creates a new empty data array. This does not allocate.
-//     pub fn new() -> Self {
-//         Self(NonNull::dangling())
-//     }
-
-//     /// Allocates a new data array with the given capacity, if any.
-//     ///
-//     ///
-//     /// # Panics
-//     ///
-//     /// This operation will panic if there is not enough memory to perform the new
-//     /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
-//     pub fn with_capacity(new_capacity: usize) -> Self {
-//         if (mem::size_of::<T>() == 0) || (new_capacity == 0) {
-//             return Self(NonNull::dangling());
-//         }
-
-//         let new_lay = new_layout::<T>(new_capacity);
-
-//         debug_assert!(new_capacity > 0);
-//         debug_assert!(new_lay.size() > 0);
-
-//         unsafe { Self(resolve_ptr(alloc::alloc(new_lay), new_lay)) }
-//     }
-
-//     /// Allocates a new block of data for this array.
-//     ///
-//     /// If this array already has allocated memory, that memory will be leaked.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - `new_capacity > 0`
-//     ///
-//     /// # Panics
-//     ///
-//     /// This operation will panic if there is not enough memory to perform the new
-//     /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
-//     pub unsafe fn alloc(&mut self, new_capacity: usize) {
-//         if mem::size_of::<T>() == 0 {
-//             return;
-//         }
-
-//         let new_layout = new_layout::<T>(new_capacity);
-
-//         debug_assert!(new_capacity > 0);
-//         debug_assert!(new_layout.size() > 0);
-
-//         unsafe {
-//             self.0 = resolve_ptr(
-//                 // SAFETY: We know that new_layout has a nonzero size.
-//                 alloc::alloc(new_layout),
-//                 new_layout,
-//             );
-//         }
-//     }
-
-//     /// Reallocates this array's old data block into a new data block.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - `new_capacity > 0`
-//     /// - `new_capacity >= old_capacity`
-//     /// - This array has exactly `old_capacity` elements allocated
-//     ///
-//     /// # Panics
-//     ///
-//     /// This operation will panic if there is not enough memory to perform the new
-//     /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
-//     pub unsafe fn realloc(&mut self, old_capacity: usize, new_capacity: usize) {
-//         if mem::size_of::<T>() == 0 {
-//             return;
-//         }
-
-//         if old_capacity == 0 {
-//             // SAFETY: The caller guarantees that new_capacity > 0.
-//             unsafe { self.alloc(new_capacity) };
-//             return;
-//         }
-
-//         let old_ptr = self.0.as_ptr() as *mut u8;
-//         let new_layout = new_layout::<T>(new_capacity);
-//         let old_layout = Layout::array::<T>(old_capacity).unwrap();
-
-//         debug_assert!(new_capacity > 0);
-//         debug_assert!(old_capacity > 0);
-//         debug_assert!(new_capacity >= old_capacity);
-//         debug_assert!(new_layout.size() > 0);
-//         debug_assert!(old_layout.size() > 0);
-//         debug_assert!(old_ptr.is_null() == false);
-
-//         unsafe {
-//             self.0 = resolve_ptr(
-//                 // SAFETY: We know that both layouts have a nonzero size.
-//                 alloc::realloc(old_ptr, old_layout, new_layout.size()),
-//                 new_layout,
-//             );
-//         }
-//     }
-
-//     /// Deallocates this array's data block.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - This array has exactly `old_capacity` elements allocated
-//     pub unsafe fn dealloc(&mut self, old_capacity: usize) {
-//         if mem::size_of::<T>() == 0 {
-//             return;
-//         }
-
-//         if old_capacity == 0 {
-//             return;
-//         }
-
-//         let old_layout = Layout::array::<T>(old_capacity).unwrap();
-
-//         debug_assert!(old_capacity > 0);
-//         debug_assert!(old_layout.size() > 0);
-
-//         unsafe {
-//             // SAFETY: We know that old_layout has a nonzero size
-//             alloc::dealloc(self.0.as_ptr() as *mut u8, old_layout);
-//             self.0 = NonNull::dangling();
-//         }
-//     }
-
-//     /// Writes an element to the given index.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - This pointer has allocated at least `index` elements
-//     /// - The element at `index` is not currently initialized
-//     #[inline(always)]
-//     unsafe fn write(&mut self, index: usize, val: T) {
-//         unsafe {
-//             // SAFETY: The caller guarantees that this slot is allocated and uninitialized.
-//             (*self.0.as_ptr().add(index)).write(val);
-//         }
-//     }
-
-//     /// Gets a slice for the range `0..len`.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - This pointer has allocated at least `len` elements
-//     /// - All elements the range `0..len` are initialized
-//     #[inline(always)]
-//     unsafe fn slice(&self, len: usize) -> &[T] {
-//         // SAFETY: Casting `slice` to a `*const [T]` is safe since the caller guarantees that
-//         // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
-//         // The pointer obtained is valid since it refers to memory owned by `slice` which is a
-//         // reference and thus guaranteed to be valid for reads.
-//         // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#972
-//         unsafe { slice::from_raw_parts(self.0.as_ptr() as *const T, len) }
-//     }
-
-//     /// Gets a mutable slice for the range `0..len`.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - This pointer has allocated at least `len` elements
-//     /// - All elements the range `0..len` are valid data
-//     #[inline(always)]
-//     unsafe fn slice_mut(&mut self, len: usize) -> &mut [T] {
-//         // SAFETY: Similar to safety notes for `assume_init_slice`, but we have a
-//         // mutable reference which is also guaranteed to be valid for writes.
-//         // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#994
-//         unsafe { slice::from_raw_parts_mut(self.0.as_ptr() as *mut T, len) }
-//     }
-
-//     /// Drops the element at `index` and replaces it with the last element in `0..len`.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - This pointer has allocated at least `len` elements
-//     /// - All elements the range `0..len` are initialized
-//     /// - `len > 0`
-//     /// - `index < len`
-//     #[inline(always)]
-//     unsafe fn swap_remove(&mut self, index: usize, len: usize) -> T {
-//         unsafe {
-//             // SAFETY: These are all guaranteed by the caller and stated above.
-//             debug_checked_assume!(len > 0);
-//             debug_checked_assume!(index < len);
-
-//             // SAFETY: The caller is guaranteeing that the element at index, and
-//             // the element at len - 1 are both valid. With this guarantee we can
-//             // safely take the element at index. We then perform a direct pointer
-//             // copy (we can't assume nonoverlapping here!) from the last element
-//             // to the one at index. This moves the data, making the data at index
-//             // initialized to the data at last, and the data at last effectively
-//             // uninitialized (though bitwise identical to the data at index).
-//             let last = len - 1;
-//             let array_ptr = self.0.as_ptr();
-//             let result = ptr::read(array_ptr.add(index)).assume_init();
-//             ptr::copy(array_ptr.add(last), array_ptr.add(index), 1);
-//             *array_ptr.add(last) = MaybeUninit::uninit(); // Hint for Miri
-//             result
-//         }
-//     }
-
-//     /// Drops all elements in the range `0..len`.
-//     ///
-//     /// # Safety
-//     ///
-//     /// It is up to the caller to guarantee the following:
-//     /// - All elements in the range `0..len` are initialized
-//     /// - `len <= N`
-//     #[inline(always)]
-//     unsafe fn drop_to(&mut self, len: usize) {
-//         unsafe {
-//             for i in 0..len {
-//                 let i_ptr = self.0.as_ptr().add(i);
-//                 // SAFETY: The caller guarantees this element is valid.
-//                 ptr::drop_in_place(i_ptr as *mut T);
-//                 ptr::write(i_ptr, MaybeUninit::uninit()); // Hint for Miri
-//             }
-//         };
-//     }
-// }
-
-// #[inline(always)]
-// fn new_layout<T>(capacity: usize) -> Layout {
-//     let layout = Layout::array::<T>(capacity).unwrap();
-//     assert!(layout.size() <= isize::MAX as usize, "allocation too large");
-//     layout
-// }
-
-// #[inline(always)]
-// fn resolve_ptr<T>(ptr: *mut u8, layout: Layout) -> NonNull<T> {
-//     match NonNull::new(ptr as *mut T) {
-//         Some(p) => p,
-//         None => alloc::handle_alloc_error(layout),
-//     }
-// }
+use std::alloc::{self, Layout};
+use std::cell::{Ref, RefCell, RefMut};
+use std::mem::{self, MaybeUninit};
+use std::ptr::{self, NonNull};
+use std::slice;
+
+use paste::paste;
+
+use crate::archetype::slices::*;
+use crate::archetype::slot::{self, Slot, SlotIndex};
+use crate::entity::Entity;
+use crate::index::{DataIndex, MAX_DATA_CAPACITY};
+use crate::traits::Archetype;
+use crate::util::{debug_checked_assume, num_assert_leq};
+
+macro_rules! declare_storage_dynamic_n {
+    ($n:literal, $($i:literal),+) => {
+        paste! {
+            pub struct [<StorageDynamic$n>]<A: Archetype, $([<T$i>],)+> {
+                len: usize,
+                capacity: usize,
+                free_head: SlotIndex,
+                slots: DataDynamic<Slot>, // Sparse
+                // No RefCell here since we never grant mutable access externally
+                entities: DataDynamic<Entity<A>>,
+                $([<d$i>]: RefCell<DataDynamic<[<T$i>]>>,)+
+            }
+
+            impl<A: Archetype, $([<T$i>],)+> [<StorageDynamic$n>]<A, $([<T$i>],)+>
+            {
+                #[inline(always)]
+                pub fn new(capacity: usize) -> Self {
+                    // We assume in a lot of places that u32 can trivially convert to usize
+                    num_assert_leq!(std::mem::size_of::<u32>(), std::mem::size_of::<usize>());
+                    // Our data indices must be able to fit inside of entity handles
+                    if capacity > MAX_DATA_CAPACITY as usize {
+                        panic!("capacity may not exceed {}", MAX_DATA_CAPACITY);
+                    }
+
+                    let mut slots: DataDynamic<Slot> = DataDynamic::new(capacity);
+                    // SAFETY: We just allocated the slot array with this capacity.
+                    let raw_data = unsafe { slots.raw_data(capacity) };
+                    let free_head = slot::populate_free_list(DataIndex::zero(), raw_data);
+
+                    Self {
+                        len: 0,
+                        capacity,
+                        free_head: free_head,
+                        slots,
+                        entities: DataDynamic::new(capacity),
+                        $([<d$i>]: RefCell::new(DataDynamic::new(capacity)),)+
+                    }
+                }
+
+                #[inline(always)]
+                pub const fn len(&self) -> usize {
+                    self.len
+                }
+
+                #[inline(always)]
+                pub const fn is_empty(&self) -> bool {
+                    self.len == 0
+                }
+
+                #[inline(always)]
+                pub const fn capacity(&self) -> usize {
+                    self.capacity
+                }
+
+                /// Reserves a slot in the map pointing to the given dense index.
+                /// Returns an entity handle if successful, or None if we're full.
+                #[inline(always)]
+                pub fn try_push(&mut self, data: ($([<T$i>],)+)) -> Option<Entity<A>> {
+                    debug_assert!(self.len <= self.capacity());
+
+                    if self.len >= self.capacity() {
+                        // If we're full, we should also be at the end of the slot free list.
+                        // WARNING: This changes if we decide to orphan version-overflow slots!
+                        debug_assert!(self.free_head.is_free_list_end());
+
+                        if self.grow() == false {
+                            return None; // Out of room to grow
+                        }
+                    }
+
+                    unsafe {
+                        // SAFETY: We will never hit the the free list end if we're below capacity
+                        // WARNING: This changes if we decide to orphan version-overflow slots!
+                        let slot_index = self.free_head.get_next_free().unwrap_unchecked();
+                        // SAFETY: We never let self.len be greater than MAX_DATA_CAPACITY.
+                        let dense_index = DataIndex::new_unchecked(self.len as u32);
+
+                        // SAFETY: We know that the slot storage is valid up to our capacity.
+                        let slots = self.slots.slice_mut(self.capacity());
+                        // SAFETY: We know this is not the end of the free list, and we know that
+                        // a free list slot index can never be assigned to an out of bounds value.
+                        let slot = slots.get_unchecked_mut(slot_index.get() as usize);
+
+                        // NOTE: Do not change the following order of operations!
+                        debug_assert!(slot.is_free());
+                        self.free_head = slot.index();
+                        slot.assign(dense_index);
+                        let entity = Entity::new(slot_index, slot.version());
+                        let index = self.len;
+                        self.len += 1;
+
+                        // SAFETY: We can't overflow because self.len < N.
+                        debug_checked_assume!(index < self.len);
+
+                        // SAFETY: We know that index < N and points to an empty cell.
+                        self.entities.write(index, entity);
+                        $(self.[<d$i>].get_mut().write(index, data.$i);)+
+
+                        Some(entity)
+                    }
+                }
+
+                /// Resolves an entity to an index in the storage data slices.
+                /// This index is guaranteed to be in bounds and point to valid data.
+                #[inline(always)]
+                pub fn resolve(&self, entity: Entity<A>) -> Option<usize> {
+                    let (_, dense_index) = match self.resolve_slot(entity) {
+                        None => { return None; }
+                        Some(found) => found,
+                    };
+
+                    let dense_index_usize = dense_index.get() as usize;
+
+                    unsafe {
+                        // SAFETY: resolve_slot guarantees this index is valid.
+                        // We assume this to help avoid bounds checks later on.
+                        debug_checked_assume!(dense_index_usize < self.len);
+                    }
+
+                    Some(dense_index_usize)
+                }
+
+                /// Removes the given entity from storage if it exists there.
+                /// Returns the removed entity's components, if any.
+                ///
+                /// # Panics
+                ///
+                /// This function may panic if a slot's generational version overflows,
+                /// in order to protect the safety of entity handle lookups. This is an
+                /// extremely unlikely occurrence in nearly all programs -- it would only
+                /// happen if the exact same lookup slot was rewritten 4.2 billion times.
+                #[inline(always)]
+                pub fn remove(&mut self, entity: Entity<A>) -> Option<($([<T$i>],)*)> {
+                    let (slot_index, dense_index) = match self.resolve_slot(entity) {
+                        None => { return None; }
+                        Some(found) => found,
+                    };
+
+                    let result = unsafe {
+                        // SAFETY: These are guaranteed by resolve_slot to be in range.
+                        let slot_index_usize: usize = slot_index.get() as usize;
+                        let dense_index_usize: usize = dense_index.get() as usize;
+
+                        debug_assert!(self.len > 0);
+                        debug_assert!(self.len <= self.capacity());
+                        debug_assert!(slot_index_usize <= self.capacity());
+                        debug_assert!(dense_index_usize < self.len);
+
+                        let entities = self.entities.slice(self.len);
+                        debug_assert!(entities.len() == self.len);
+                        debug_assert!(entities[dense_index_usize].index() == entity.index());
+                        debug_assert!(entities[dense_index_usize].version() == entity.version());
+
+                        // SAFETY: We know self.len > 0 because we got Some from resolve_slot.
+                        let last_dense_index = self.len - 1;
+                        // SAFETY: We know the entity slice has a length of self.len.
+                        let last_entity = *entities.get_unchecked(last_dense_index);
+                        // SAFETY: We guarantee that stored entities point to valid slots.
+                        let last_slot_index: usize = last_entity.index().get() as usize;
+
+                        // Perform the swap_remove on our data to drop the target entity.
+                        // SAFETY: We guarantee that non-free slots point to valid dense data.
+                        self.entities.swap_remove(dense_index_usize, self.len);
+                        let result =
+                            ($(self.[<d$i>].get_mut().swap_remove(dense_index_usize, self.len),)+);
+
+                        // SAFETY: We know that the slot storage is valid up to our capacity.
+                        let slots = self.slots.slice_mut(self.capacity());
+
+                        // NOTE: Order matters here to support the (target == last) case!
+                        // Fix up the slot pointing to the last entity
+                        slots
+                            .get_unchecked_mut(last_slot_index) // SAFETY: See declaration.
+                            .assign(dense_index);
+                        // Return the target slot to the free list
+                        slots
+                            .get_unchecked_mut(slot_index_usize) // SAFETY: See declaration.
+                            .release(self.free_head)
+                            .expect("slot version overflow"); // Wow, 4 billion slot writes!
+                        // NOTE: We could orphan this slot instead, but this would break the
+                        // assumptions we make elsewhere (see the WARNING in try_push, etc.)
+                        // that the end of the free list and len == capacity are synonymous.
+                        // Enabling slot orphaning would create a lot of edge cases to fix.
+
+                        result
+                    };
+
+                    // TODO: We shouldn't add a slot to the free list if its version number
+                    // is maxed out. It would be better to orphan that slot to avoid issues.
+
+                    // Update the free list head
+                    self.free_head = SlotIndex::new_free(entity.index());
+                    self.len -= 1;
+
+                    Some(result)
+                }
+
+                /// Populates a slice struct with slices to our stored data.
+                #[inline(always)]
+                pub fn get_all_slices<'a, S: [<Slices$n>]<'a, A, $([<T$i>],)+>>(&'a mut self,) -> S {
+                    unsafe {
+                        // SAFETY: We guarantee that the storage is valid up to self.len.
+                        S::new(
+                            self.entities.slice(self.len),
+                            $(self.[<d$i>].get_mut().slice_mut(self.len)),+
+                        )
+                    }
+                }
+
+                /// Gets a read-only slice of our currently stored entity handles.
+                #[inline(always)]
+                pub fn get_slice_entities(&self) -> &[Entity<A>] {
+                    unsafe {
+                        // SAFETY: We guarantee that the storage is valid up to self.len.
+                        self.entities.slice(self.len)
+                    }
+                }
+
+                $(
+                    /// Gets a slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<get_slice_$i>](&mut self) -> &[[<T$i>]] {
+                        unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            self.[<d$i>].get_mut().slice(self.len)
+                        }
+                    }
+
+                    /// Gets a slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<get_slice_mut_$i>](&mut self) -> &mut [[<T$i>]] {
+                        unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            self.[<d$i>].get_mut().slice_mut(self.len)
+                        }
+                    }
+
+                    /// Borrows the slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<borrow_slice_$i>](&self) -> Ref<[[<T$i>]]> {
+                        Ref::map(self.[<d$i>].borrow(), |slice| unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            slice.slice(self.len)
+                        })
+                    }
+
+                    /// Mutably borrows the slice of the given component index.
+                    #[inline(always)]
+                    pub fn [<borrow_slice_mut_$i>](&self) -> RefMut<[[<T$i>]]> {
+                        RefMut::map(self.[<d$i>].borrow_mut(), |slice| unsafe {
+                            // SAFETY: We guarantee that the storage is valid up to self.len.
+                            slice.slice_mut(self.len)
+                        })
+                    }
+                )+
+
+                /// Resolves the slot index and data index for a given entity.
+                /// Both indices are guaranteed to point to valid cells.
+                #[inline(always)]
+                fn resolve_slot(&self, entity: Entity<A>) -> Option<(DataIndex, DataIndex)> {
+                    // Nothing to resolve if we have nothing stored
+                    if self.len == 0 {
+                        return None;
+                    }
+
+                    // Get the index into the slot array from the entity.
+                    let slot_index = entity.index();
+
+                    unsafe {
+                        let slot_index_usize = slot_index.get() as usize;
+
+                        // NOTE: It's a little silly, but we don't actually know if this entity
+                        // was created by this map, so we can't assume internal consistency here.
+                        // We'll just have to take the small hit for bounds checking on the index.
+                        if slot_index_usize >= self.capacity() {
+                            panic!("entity handle is invalid for this archetype");
+                        }
+
+                        // SAFETY: We know that the slot storage is valid up to our capacity.
+                        let slots = self.slots.slice(self.capacity());
+                        // SAFETY: We know slot_index_usize is within bounds due to the panic above.
+                        let slot = slots.get_unchecked(slot_index_usize);
+
+                        // NOTE: For similar reasons above, a crossed-wires entity handle from another
+                        // world could miraculously have the correct version while pointing to a freed
+                        // slot. This could cause some wacky memory access, so we need to allow slots
+                        // to be explicitly identified as free or not. Again, this has a small cost.
+                        if (slot.version() != entity.version()) || slot.is_free() {
+                            return None; // Stale entity handle, fail the lookup
+                        }
+
+                        // SAFETY: We know that this is not a free slot due to the check above.
+                        let dense_index = slot.index().get_data().unwrap_unchecked();
+
+                        Some((slot_index, dense_index))
+                    }
+                }
+
+                /// Grows the storage structure to accommodate more entries.
+                ///
+                /// This wipes the current free list and rebuilds it, including the list head.
+                #[inline(always)]
+                fn grow(&mut self) -> bool {
+                    if self.capacity() >= MAX_DATA_CAPACITY as usize {
+                        return false; // Out of space to grow
+                    }
+
+                    debug_assert!(self.len == self.capacity);
+
+                    let new_capacity = self.capacity.saturating_add(1).saturating_mul(2);
+                    let new_capacity = new_capacity.min(MAX_DATA_CAPACITY as usize);
+
+                    unsafe {
+                        // SAFETY: We know new_capacity > self.capacity and is nonzero.
+                        self.slots.grow(self.capacity, new_capacity);
+                        self.entities.grow(self.capacity, new_capacity);
+                        $( self.[<d$i>].get_mut().grow(self.capacity, new_capacity); )*
+
+                        // SAFETY: We know self.len < MAX_DATA_CAPACITY.
+                        let free_list_start = DataIndex::new_unchecked(self.len as u32);
+                        // SAFETY: We just grew the slot data array up to new_capacity.
+                        let raw_data = self.slots.raw_data(new_capacity);
+                        // SAFETY: We know that self.len < new_capacity.
+                        let new_free_list = raw_data.get_unchecked_mut(self.len..);
+
+                        // Populate the end of the list as the new free list. We are
+                        // assuming here that, because we are full, every slot is occupied
+                        // and so our free list is entirely empty. Thus, we need a new one.
+                        self.free_head = slot::populate_free_list(free_list_start, new_free_list);
+                    }
+
+                    todo!();
+                }
+            }
+
+            impl<A: Archetype, $([<T$i>],)+> Drop
+                for [<StorageDynamic$n>]<A, $([<T$i>],)+>
+            {
+                #[inline(always)]
+                fn drop(&mut self) {
+                    // SAFETY: We guarantee that the storage is valid up to self.len.
+                    unsafe {
+                        $(self.[<d$i>].get_mut().drop_to(self.len);)+
+                        // We don't need to drop the other stuff since it's all trivial.
+                    };
+                }
+            }
+
+            impl<A: Archetype, $([<T$i>],)+> Default
+                for [<StorageDynamic$n>]<A, $([<T$i>],)+>
+            {
+                #[inline(always)]
+                fn default() -> Self {
+                    [<StorageDynamic$n>]::new(0)
+                }
+            }
+        }
+    };
+}
+
+declare_storage_dynamic_n!(1, 0);
+declare_storage_dynamic_n!(2, 0, 1);
+declare_storage_dynamic_n!(3, 0, 1, 2);
+declare_storage_dynamic_n!(4, 0, 1, 2, 3);
+declare_storage_dynamic_n!(5, 0, 1, 2, 3, 4);
+declare_storage_dynamic_n!(6, 0, 1, 2, 3, 4, 5);
+declare_storage_dynamic_n!(7, 0, 1, 2, 3, 4, 5, 6);
+declare_storage_dynamic_n!(8, 0, 1, 2, 3, 4, 5, 6, 7);
+declare_storage_dynamic_n!(9, 0, 1, 2, 3, 4, 5, 6, 7, 8);
+declare_storage_dynamic_n!(10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+declare_storage_dynamic_n!(11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+declare_storage_dynamic_n!(12, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+declare_storage_dynamic_n!(13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+declare_storage_dynamic_n!(14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+declare_storage_dynamic_n!(15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+declare_storage_dynamic_n!(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+pub struct DataDynamic<T>(NonNull<MaybeUninit<T>>);
+
+impl<T> DataDynamic<T> {
+    /// Allocates a new data array with the given capacity, if any.
+    ///
+    /// If `T` is zero-sized, or the given capacity is 0, this will not allocate.
+    ///
+    /// # Panics
+    ///
+    /// This operation will panic if there is not enough memory to perform the new
+    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+    pub fn new(capacity: usize) -> Self {
+        if (mem::size_of::<T>() == 0) || (capacity == 0) {
+            return Self(NonNull::dangling());
+        }
+
+        let layout = new_layout::<T>(capacity);
+
+        debug_assert!(capacity > 0);
+        debug_assert!(layout.size() > 0);
+
+        unsafe { Self(resolve_ptr(alloc::alloc(layout), layout)) }
+    }
+
+    /// Gets the raw stored data up to `len` as a mutable `MaybeUninit<T>` slice.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This array has at least `len` elements allocated
+    pub unsafe fn raw_data(&mut self, len: usize) -> &mut [MaybeUninit<T>] {
+        // SAFETY: The caller guarantees that we have at least len elements allocated.
+        unsafe { slice::from_raw_parts_mut(self.0.as_ptr(), len) }
+    }
+
+    /// Reallocates this array's old data block into a new data block.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - `capacity >= old_capacity`
+    /// - This array has exactly `old_capacity` elements allocated (may be 0)
+    ///
+    /// # Panics
+    ///
+    /// This operation will panic if there is not enough memory to perform the new
+    /// allocation, or if the resulting allocation size is greater than `isize::MAX`.
+    pub unsafe fn grow(&mut self, old_capacity: usize, capacity: usize) {
+        debug_assert!(capacity >= old_capacity);
+
+        if (mem::size_of::<T>() == 0) || (capacity == 0) {
+            return; // Stay dangling
+        }
+
+        let layout = new_layout::<T>(capacity);
+        let size = layout.size();
+        debug_assert!(size > 0);
+
+        unsafe {
+            if old_capacity == 0 {
+                // SAFETY: The caller guarantees that capacity > 0.
+                self.0 = resolve_ptr(alloc::alloc(layout), layout);
+            } else {
+                // SAFETY: The caller guarantees that this is allocated.
+                let old_ptr = self.0.as_ptr() as *mut u8;
+                // SAFETY: We checked that T is not a ZST and old_capacity > 0.
+                let old_layout = Layout::array::<T>(old_capacity).unwrap();
+
+                debug_assert!(old_ptr.is_null() == false);
+                debug_assert!(old_layout.size() > 0);
+
+                // SAFETY: The caller guarantees that capacity > 0.
+                self.0 = resolve_ptr(alloc::realloc(old_ptr, old_layout, size), layout);
+            }
+        }
+    }
+
+    /// Deallocates this array's data block.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This array has exactly `old_capacity` elements allocated
+    pub unsafe fn dealloc(&mut self, old_capacity: usize) {
+        if mem::size_of::<T>() == 0 {
+            return;
+        }
+
+        if old_capacity == 0 {
+            return;
+        }
+
+        let old_layout = Layout::array::<T>(old_capacity).unwrap();
+
+        debug_assert!(old_capacity > 0);
+        debug_assert!(old_layout.size() > 0);
+
+        unsafe {
+            // SAFETY: We know that old_layout has a nonzero size
+            alloc::dealloc(self.0.as_ptr() as *mut u8, old_layout);
+            self.0 = NonNull::dangling();
+        }
+    }
+
+    /// Writes an element to the given index.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `index` elements
+    /// - The element at `index` is currently invalid
+    #[inline(always)]
+    unsafe fn write(&mut self, index: usize, val: T) {
+        unsafe {
+            // SAFETY: The caller guarantees that this slot is allocated and invalid.
+            (*self.0.as_ptr().add(index)).write(val);
+        }
+    }
+
+    /// Gets a slice for the range `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `len` elements
+    /// - All elements the range `0..len` are valid
+    #[inline(always)]
+    unsafe fn slice(&self, len: usize) -> &[T] {
+        unsafe {
+            // SAFETY: Casting a `[MaybeUninit<T>]` to a `[T]` is safe because the caller
+            // guarantees that this portion of the data is valid and `MaybeUninit<T>` is
+            // guaranteed to have the same layout as `T`. The pointer obtained is valid
+            // since it refers to memory owned by `slice` which is a reference and thus
+            // guaranteed to be valid for reads.
+            // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#972
+            slice::from_raw_parts(self.0.as_ptr() as *const T, len)
+        }
+    }
+
+    /// Gets a mutable slice for the range `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `len` elements
+    /// - All elements the range `0..len` are valid
+    #[inline(always)]
+    unsafe fn slice_mut(&mut self, len: usize) -> &mut [T] {
+        unsafe {
+            // SAFETY: Similar to safety notes for `slice`, but we have a mutable reference
+            // which is also guaranteed to be valid for writes.
+            // Ref: https://doc.rust-lang.org/stable/src/core/mem/maybe_uninit.rs.html#994
+            slice::from_raw_parts_mut(self.0.as_ptr() as *mut T, len)
+        }
+    }
+
+    /// Drops the element at `index` and replaces it with the last element in `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - This pointer has allocated at least `len` elements
+    /// - All elements the range `0..len` are valid
+    /// - `len > 0`
+    /// - `index < len`
+    #[inline(always)]
+    unsafe fn swap_remove(&mut self, index: usize, len: usize) -> T {
+        unsafe {
+            debug_assert!(len > 0);
+            debug_assert!(index < len);
+
+            // SAFETY: The caller is guaranteeing that the element at index, and
+            // the element at len - 1 are both valid. With this guarantee we can
+            // safely take the element at index. We then perform a direct pointer
+            // copy (we can't assume nonoverlapping here!) from the last element
+            // to the one at index. This moves the data, making the data at index
+            // valid to the data at last, and the data at last invalid (even if
+            // it is still bitwise identical to the data at index).
+            let last = len - 1;
+            let array_ptr = self.0.as_ptr();
+            let result = ptr::read(array_ptr.add(index)).assume_init();
+            ptr::copy(array_ptr.add(last), array_ptr.add(index), 1);
+            *array_ptr.add(last) = MaybeUninit::uninit(); // Hint for Miri
+            result
+        }
+    }
+
+    /// Drops all elements in the range `0..len`.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee the following:
+    /// - All elements in the range `0..len` are valid
+    /// - `len <= N`
+    #[inline(always)]
+    unsafe fn drop_to(&mut self, len: usize) {
+        unsafe {
+            for i in 0..len {
+                let i_ptr = self.0.as_ptr().add(i);
+                // SAFETY: The caller guarantees this element is valid.
+                ptr::drop_in_place(i_ptr as *mut T);
+                ptr::write(i_ptr, MaybeUninit::uninit()); // Hint for Miri
+            }
+        };
+    }
+}
+
+#[inline(always)]
+fn new_layout<T>(capacity: usize) -> Layout {
+    let layout = Layout::array::<T>(capacity).unwrap();
+    assert!(layout.size() <= isize::MAX as usize, "allocation too large");
+    layout
+}
+
+#[inline(always)]
+fn resolve_ptr<T>(ptr: *mut u8, layout: Layout) -> NonNull<T> {
+    match NonNull::new(ptr as *mut T) {
+        Some(p) => p,
+        None => alloc::handle_alloc_error(layout),
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,51 @@
+use crate::entity::ARCHETYPE_ID_BITS;
+use crate::util::{debug_checked_assume, num_assert_lt};
+
+pub(crate) const MAX_DATA_CAPACITY: u32 = 1 << (u32::BITS - ARCHETYPE_ID_BITS);
+pub(crate) const MAX_DATA_INDEX: u32 = MAX_DATA_CAPACITY - 1;
+
+/// A size-checked index that can always fit in an entity and live slot.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct DataIndex(u32);
+
+impl DataIndex {
+    /// Creates a `DataIndex` pointing to zero.
+    #[inline(always)]
+    pub(crate) const fn zero() -> Self {
+        // Better safe than sorry I guess...
+        num_assert_lt!(0, MAX_DATA_INDEX as usize);
+        Self(0)
+    }
+
+    /// Creates a new `DataIndex` if the given index is within bounds.
+    #[inline(always)]
+    pub(crate) const fn new(index: u32) -> Option<Self> {
+        match index < MAX_DATA_CAPACITY {
+            true => Some(Self(index)),
+            false => None,
+        }
+    }
+
+    /// Creates a new `DataIndex` without checking any bounds.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that `index < INDEX_MAX`.
+    #[inline(always)]
+    pub(crate) unsafe fn new_unchecked(index: u32) -> Self {
+        debug_assert!(index < MAX_DATA_CAPACITY);
+        Self(index)
+    }
+
+    /// Gets the raw value of this `DataIndex`.
+    ///
+    /// The result is guaranteed to be less than `INDEX_MAX`.
+    #[inline(always)]
+    pub(crate) fn get(self) -> u32 {
+        unsafe {
+            // SAFETY: This is verified at creation
+            debug_checked_assume!(self.0 < MAX_DATA_CAPACITY);
+            self.0
+        }
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -30,7 +30,7 @@ impl DataIndex {
     ///
     /// # Safety
     ///
-    /// The caller must guarantee that `index < INDEX_MAX`.
+    /// The caller must guarantee that `index < MAX_DATA_CAPACITY`.
     #[inline(always)]
     pub(crate) unsafe fn new_unchecked(index: u32) -> Self {
         debug_assert!(index < MAX_DATA_CAPACITY);
@@ -39,7 +39,7 @@ impl DataIndex {
 
     /// Gets the raw value of this `DataIndex`.
     ///
-    /// The result is guaranteed to be less than `INDEX_MAX`.
+    /// The result is guaranteed to be less than `MAX_DATA_CAPACITY`.
     #[inline(always)]
     pub(crate) fn get(self) -> u32 {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@
 //! ```
 
 mod archetype;
+mod index;
 mod util;
 
 /// Handles for accessing entity representations as component data.
@@ -102,8 +103,6 @@ pub mod error;
 
 /// Traits for working with ECS types as generics.
 pub mod traits;
-
-/// Test
 
 #[cfg(doc)]
 mod macros {
@@ -675,7 +674,7 @@ pub mod prelude {
 
     pub use gecs_macros::{ecs_component_id, ecs_world};
 
-    pub use entity::{Entity, EntityAny};
+    pub use entity::{ArchetypeId, Entity, EntityAny};
     pub use traits::Archetype;
     pub use traits::{ArchetypeContainer, ComponentContainer};
     pub use traits::{HasArchetype, HasComponent};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 use std::cell::{Ref, RefMut};
 
-use crate::entity::Entity;
+use crate::entity::{ArchetypeId, Entity};
 
 /// A trait describing each archetype in a given ECS world.
 ///
@@ -10,7 +10,7 @@ use crate::entity::Entity;
 /// it is not intended to be manually implemented by any user data structures.
 pub trait Archetype: Sized {
     /// A unique type ID assigned to this archetype in generation.
-    const ARCHETYPE_ID: u8;
+    const ARCHETYPE_ID: ArchetypeId;
 
     /// A tuple of the components in this archetype.
     type Components;

--- a/tests/test_single.rs
+++ b/tests/test_single.rs
@@ -5,12 +5,14 @@ mod inner {
 }
 
 pub struct CompA(pub u32);
+pub struct CompZ; // ZST
 
 ecs_world! {
     ecs_archetype!(
         ArchFoo,
         inner::TEST_CAPACITY + 1, // Should be 5 total for tests
         CompA,
+        CompZ,
     );
 }
 
@@ -25,15 +27,15 @@ pub fn test_archetype_id() {
 pub fn test_single_push() {
     let mut world = World::default();
 
-    world.arch_foo.push((CompA(0),));
-    world.arch_foo.push((CompA(1),));
-    world.arch_foo.push((CompA(2),));
-    world.arch_foo.push((CompA(3),));
-    world.arch_foo.push((CompA(4),));
+    world.arch_foo.push((CompA(0), CompZ,));
+    world.arch_foo.push((CompA(1), CompZ,));
+    world.arch_foo.push((CompA(2), CompZ,));
+    world.arch_foo.push((CompA(3), CompZ,));
+    world.arch_foo.push((CompA(4), CompZ,));
 
     assert_eq!(world.arch_foo.len(), 5);
 
-    assert!(world.arch_foo.try_push((CompA(6),)).is_none());
+    assert!(world.arch_foo.try_push((CompA(6), CompZ,)).is_none());
 }
 
 #[test]
@@ -41,11 +43,11 @@ pub fn test_single_push() {
 pub fn test_single_entity() {
     let mut world = World::default();
 
-    let entity_0 = world.arch_foo.push((CompA(0),));
-    let entity_1 = world.arch_foo.push((CompA(1),));
-    let entity_2 = world.arch_foo.push((CompA(2),));
-    let entity_3 = world.arch_foo.push((CompA(3),));
-    let entity_4 = world.arch_foo.push((CompA(4),));
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     assert!(ecs_find!(world, entity_0, |v: &Entity<ArchFoo>| assert!(*v == entity_0)));
     assert!(ecs_find!(world, entity_1, |v: &Entity<ArchFoo>| assert!(*v == entity_1)));
@@ -65,11 +67,11 @@ pub fn test_single_entity() {
     assert!(world.arch_foo.remove(entity_3).is_some());
     assert!(world.arch_foo.remove(entity_4).is_some());
 
-    let entity_0b = world.arch_foo.push((CompA(0),));
-    let entity_1b = world.arch_foo.push((CompA(1),));
-    let entity_2b = world.arch_foo.push((CompA(2),));
-    let entity_3b = world.arch_foo.push((CompA(3),));
-    let entity_4b = world.arch_foo.push((CompA(4),));
+    let entity_0b = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1b = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2b = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3b = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4b = world.arch_foo.push((CompA(4), CompZ,));
 
     assert!(entity_0 != entity_0b);
     assert!(entity_1 != entity_1b);
@@ -95,11 +97,11 @@ pub fn test_single_entity() {
 pub fn test_single_find() {
     let mut world = World::default();
 
-    let entity_0 = world.arch_foo.push((CompA(0),));
-    let entity_1 = world.arch_foo.push((CompA(1),));
-    let entity_2 = world.arch_foo.push((CompA(2),));
-    let entity_3 = world.arch_foo.push((CompA(3),));
-    let entity_4 = world.arch_foo.push((CompA(4),));
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     assert!(ecs_find!(world, entity_0, |v: &CompA| assert_eq!(v.0, 0)));
     assert!(ecs_find!(world, entity_1, |v: &CompA| assert_eq!(v.0, 1)));
@@ -159,11 +161,11 @@ pub fn test_single_find() {
 pub fn test_single_iter() {
     let mut world = World::default();
 
-    let _entity_0 = world.arch_foo.push((CompA(0),));
-    let _entity_1 = world.arch_foo.push((CompA(1),));
-    let _entity_2 = world.arch_foo.push((CompA(2),));
-    let _entity_3 = world.arch_foo.push((CompA(3),));
-    let _entity_4 = world.arch_foo.push((CompA(4),));
+    let _entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let _entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let _entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let _entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let _entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     let mut sum = 0;
     ecs_iter!(world, |v: &CompA| sum += v.0);
@@ -205,11 +207,11 @@ pub fn test_single_iter() {
 pub fn test_single_iter_write() {
     let mut world = World::default();
 
-    let _entity_0 = world.arch_foo.push((CompA(0),));
-    let _entity_1 = world.arch_foo.push((CompA(1),));
-    let _entity_2 = world.arch_foo.push((CompA(2),));
-    let _entity_3 = world.arch_foo.push((CompA(3),));
-    let _entity_4 = world.arch_foo.push((CompA(4),));
+    let _entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let _entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let _entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let _entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let _entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     ecs_iter!(world, |v: &mut CompA| v.0 += 100);
 
@@ -253,11 +255,11 @@ pub fn test_single_iter_write() {
 pub fn test_single_remove_replace() {
     let mut world = World::default();
 
-    let entity_0 = world.arch_foo.push((CompA(0),));
-    let entity_1 = world.arch_foo.push((CompA(1),));
-    let entity_2 = world.arch_foo.push((CompA(2),));
-    let entity_3 = world.arch_foo.push((CompA(3),));
-    let entity_4 = world.arch_foo.push((CompA(4),));
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     assert_eq!(world.arch_foo.len(), 5);
 
@@ -294,11 +296,11 @@ pub fn test_single_remove_replace() {
     assert!(world.arch_foo.remove(entity_3).is_none());
     assert!(world.arch_foo.remove(entity_4).is_none());
 
-    let entity_0b = world.arch_foo.push((CompA(1000),));
-    let entity_1b = world.arch_foo.push((CompA(1001),));
-    let entity_2b = world.arch_foo.push((CompA(1002),));
-    let entity_3b = world.arch_foo.push((CompA(1003),));
-    let entity_4b = world.arch_foo.push((CompA(1004),));
+    let entity_0b = world.arch_foo.push((CompA(1000), CompZ,));
+    let entity_1b = world.arch_foo.push((CompA(1001), CompZ,));
+    let entity_2b = world.arch_foo.push((CompA(1002), CompZ,));
+    let entity_3b = world.arch_foo.push((CompA(1003), CompZ,));
+    let entity_4b = world.arch_foo.push((CompA(1004), CompZ,));
 
     assert!(ecs_find!(world, entity_0b, |v: &CompA| assert_eq!(v.0, 1000)));
     assert!(ecs_find!(world, entity_1b, |v: &CompA| assert_eq!(v.0, 1001)));

--- a/tests/test_single_dyn.rs
+++ b/tests/test_single_dyn.rs
@@ -1,0 +1,302 @@
+use gecs::prelude::*;
+
+pub struct CompA(pub u32);
+
+ecs_world! {
+    ecs_archetype!(
+        ArchFoo,
+        dyn,
+        CompA,
+    );
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_push() {
+    let mut world = World::default();
+
+    world.arch_foo.push((CompA(0),));
+    world.arch_foo.push((CompA(1),));
+    world.arch_foo.push((CompA(2),));
+    world.arch_foo.push((CompA(3),));
+    world.arch_foo.push((CompA(4),));
+
+    assert_eq!(world.arch_foo.len(), 5);
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_entity() {
+    let mut world = World::default();
+
+    let entity_0 = world.arch_foo.push((CompA(0),));
+    let entity_1 = world.arch_foo.push((CompA(1),));
+    let entity_2 = world.arch_foo.push((CompA(2),));
+    let entity_3 = world.arch_foo.push((CompA(3),));
+    let entity_4 = world.arch_foo.push((CompA(4),));
+
+    assert!(ecs_find!(world, entity_0, |v: &Entity<ArchFoo>| assert!(*v == entity_0)));
+    assert!(ecs_find!(world, entity_1, |v: &Entity<ArchFoo>| assert!(*v == entity_1)));
+    assert!(ecs_find!(world, entity_2, |v: &Entity<ArchFoo>| assert!(*v == entity_2)));
+    assert!(ecs_find!(world, entity_3, |v: &Entity<ArchFoo>| assert!(*v == entity_3)));
+    assert!(ecs_find!(world, entity_4, |v: &Entity<ArchFoo>| assert!(*v == entity_4)));
+
+    assert!(ecs_find_borrow!(world, entity_0, |v: &Entity<ArchFoo>| assert!(*v == entity_0)));
+    assert!(ecs_find_borrow!(world, entity_1, |v: &Entity<ArchFoo>| assert!(*v == entity_1)));
+    assert!(ecs_find_borrow!(world, entity_2, |v: &Entity<ArchFoo>| assert!(*v == entity_2)));
+    assert!(ecs_find_borrow!(world, entity_3, |v: &Entity<ArchFoo>| assert!(*v == entity_3)));
+    assert!(ecs_find_borrow!(world, entity_4, |v: &Entity<ArchFoo>| assert!(*v == entity_4)));
+
+    assert!(world.arch_foo.remove(entity_0).is_some());
+    assert!(world.arch_foo.remove(entity_1).is_some());
+    assert!(world.arch_foo.remove(entity_2).is_some());
+    assert!(world.arch_foo.remove(entity_3).is_some());
+    assert!(world.arch_foo.remove(entity_4).is_some());
+
+    let entity_0b = world.arch_foo.push((CompA(0),));
+    let entity_1b = world.arch_foo.push((CompA(1),));
+    let entity_2b = world.arch_foo.push((CompA(2),));
+    let entity_3b = world.arch_foo.push((CompA(3),));
+    let entity_4b = world.arch_foo.push((CompA(4),));
+
+    assert!(entity_0 != entity_0b);
+    assert!(entity_1 != entity_1b);
+    assert!(entity_2 != entity_2b);
+    assert!(entity_3 != entity_3b);
+    assert!(entity_4 != entity_4b);
+
+    assert!(ecs_find!(world, entity_0b, |v: &Entity<ArchFoo>| assert!(*v == entity_0b)));
+    assert!(ecs_find!(world, entity_1b, |v: &Entity<ArchFoo>| assert!(*v == entity_1b)));
+    assert!(ecs_find!(world, entity_2b, |v: &Entity<ArchFoo>| assert!(*v == entity_2b)));
+    assert!(ecs_find!(world, entity_3b, |v: &Entity<ArchFoo>| assert!(*v == entity_3b)));
+    assert!(ecs_find!(world, entity_4b, |v: &Entity<ArchFoo>| assert!(*v == entity_4b)));
+
+    assert!(ecs_find_borrow!(world, entity_0b, |v: &Entity<ArchFoo>| assert!(*v == entity_0b)));
+    assert!(ecs_find_borrow!(world, entity_1b, |v: &Entity<ArchFoo>| assert!(*v == entity_1b)));
+    assert!(ecs_find_borrow!(world, entity_2b, |v: &Entity<ArchFoo>| assert!(*v == entity_2b)));
+    assert!(ecs_find_borrow!(world, entity_3b, |v: &Entity<ArchFoo>| assert!(*v == entity_3b)));
+    assert!(ecs_find_borrow!(world, entity_4b, |v: &Entity<ArchFoo>| assert!(*v == entity_4b)));
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_find() {
+    let mut world = World::default();
+
+    let entity_0 = world.arch_foo.push((CompA(0),));
+    let entity_1 = world.arch_foo.push((CompA(1),));
+    let entity_2 = world.arch_foo.push((CompA(2),));
+    let entity_3 = world.arch_foo.push((CompA(3),));
+    let entity_4 = world.arch_foo.push((CompA(4),));
+
+    assert!(ecs_find!(world, entity_0, |v: &CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find!(world, entity_1, |v: &CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find!(world, entity_2, |v: &CompA| assert_eq!(v.0, 2)));
+    assert!(ecs_find!(world, entity_3, |v: &CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find!(world, entity_4, |v: &CompA| assert_eq!(v.0, 4)));
+
+    assert!(ecs_find_borrow!(world, entity_0, |v: &CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find_borrow!(world, entity_1, |v: &CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find_borrow!(world, entity_2, |v: &CompA| assert_eq!(v.0, 2)));
+    assert!(ecs_find_borrow!(world, entity_3, |v: &CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find_borrow!(world, entity_4, |v: &CompA| assert_eq!(v.0, 4)));
+
+    assert!(ecs_find!(world, entity_0, |v: &mut CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find!(world, entity_1, |v: &mut CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find!(world, entity_2, |v: &mut CompA| assert_eq!(v.0, 2)));
+    assert!(ecs_find!(world, entity_3, |v: &mut CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find!(world, entity_4, |v: &mut CompA| assert_eq!(v.0, 4)));
+
+    assert!(ecs_find_borrow!(world, entity_0, |v: &mut CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find_borrow!(world, entity_1, |v: &mut CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find_borrow!(world, entity_2, |v: &mut CompA| assert_eq!(v.0, 2)));
+    assert!(ecs_find_borrow!(world, entity_3, |v: &mut CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find_borrow!(world, entity_4, |v: &mut CompA| assert_eq!(v.0, 4)));
+
+    world.arch_foo.remove(entity_2).unwrap();
+
+    assert!(ecs_find!(world, entity_0, |v: &CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find!(world, entity_1, |v: &CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find!(world, entity_3, |v: &CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find!(world, entity_4, |v: &CompA| assert_eq!(v.0, 4)));
+
+    assert!(ecs_find_borrow!(world, entity_0, |v: &CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find_borrow!(world, entity_1, |v: &CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find_borrow!(world, entity_3, |v: &CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find_borrow!(world, entity_4, |v: &CompA| assert_eq!(v.0, 4)));
+
+    assert!(ecs_find!(world, entity_0, |v: &mut CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find!(world, entity_1, |v: &mut CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find!(world, entity_3, |v: &mut CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find!(world, entity_4, |v: &mut CompA| assert_eq!(v.0, 4)));
+
+    assert!(ecs_find_borrow!(world, entity_0, |v: &mut CompA| assert_eq!(v.0, 0)));
+    assert!(ecs_find_borrow!(world, entity_1, |v: &mut CompA| assert_eq!(v.0, 1)));
+    assert!(ecs_find_borrow!(world, entity_3, |v: &mut CompA| assert_eq!(v.0, 3)));
+    assert!(ecs_find_borrow!(world, entity_4, |v: &mut CompA| assert_eq!(v.0, 4)));
+
+    assert_eq!(ecs_find!(world, entity_2, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find!(world, entity_2, |_: &mut CompA| panic!()), false);
+
+    assert_eq!(ecs_find_borrow!(world, entity_2, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find_borrow!(world, entity_2, |_: &mut CompA| panic!()), false);
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_iter() {
+    let mut world = World::default();
+
+    let _entity_0 = world.arch_foo.push((CompA(0),));
+    let _entity_1 = world.arch_foo.push((CompA(1),));
+    let _entity_2 = world.arch_foo.push((CompA(2),));
+    let _entity_3 = world.arch_foo.push((CompA(3),));
+    let _entity_4 = world.arch_foo.push((CompA(4),));
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 0+1+2+3+4);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 0+1+2+3+4);
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 0+1+2+3+4);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 0+1+2+3+4);
+
+    world.arch_foo.remove(_entity_2).unwrap();
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 0+1+3+4);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 0+1+3+4);
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 0+1+3+4);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 0+1+3+4);
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_iter_write() {
+    let mut world = World::default();
+
+    let _entity_0 = world.arch_foo.push((CompA(0),));
+    let _entity_1 = world.arch_foo.push((CompA(1),));
+    let _entity_2 = world.arch_foo.push((CompA(2),));
+    let _entity_3 = world.arch_foo.push((CompA(3),));
+    let _entity_4 = world.arch_foo.push((CompA(4),));
+
+    ecs_iter!(world, |v: &mut CompA| v.0 += 100);
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 100+101+102+103+104);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 100+101+102+103+104);
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 100+101+102+103+104);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 100+101+102+103+104);
+
+    world.arch_foo.remove(_entity_2).unwrap();
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 100+101+103+104);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &CompA| sum += v.0);
+    assert_eq!(sum, 100+101+103+104);
+
+    let mut sum = 0;
+    ecs_iter!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 100+101+103+104);
+
+    let mut sum = 0;
+    ecs_iter_borrow!(world, |v: &mut CompA| sum += v.0);
+    assert_eq!(sum, 100+101+103+104);
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_remove_replace() {
+    let mut world = World::default();
+
+    let entity_0 = world.arch_foo.push((CompA(0),));
+    let entity_1 = world.arch_foo.push((CompA(1),));
+    let entity_2 = world.arch_foo.push((CompA(2),));
+    let entity_3 = world.arch_foo.push((CompA(3),));
+    let entity_4 = world.arch_foo.push((CompA(4),));
+
+    assert_eq!(world.arch_foo.len(), 5);
+
+    assert_eq!(world.arch_foo.remove(entity_4).unwrap().0.0, 4);
+    assert_eq!(world.arch_foo.len(), 4);
+
+    assert_eq!(world.arch_foo.remove(entity_1).unwrap().0.0, 1);
+    assert_eq!(world.arch_foo.len(), 3);
+
+    assert_eq!(world.arch_foo.remove(entity_2).unwrap().0.0, 2);
+    assert_eq!(world.arch_foo.len(), 2);
+
+    assert_eq!(world.arch_foo.remove(entity_3).unwrap().0.0, 3);
+    assert_eq!(world.arch_foo.len(), 1);
+
+    assert_eq!(world.arch_foo.remove(entity_0).unwrap().0.0, 0);
+    assert_eq!(world.arch_foo.len(), 0);
+
+    assert_eq!(ecs_find!(world, entity_0, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find!(world, entity_1, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find!(world, entity_2, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find!(world, entity_3, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find!(world, entity_4, |_: &CompA| panic!()), false);
+
+    assert_eq!(ecs_find_borrow!(world, entity_0, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find_borrow!(world, entity_1, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find_borrow!(world, entity_2, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find_borrow!(world, entity_3, |_: &CompA| panic!()), false);
+    assert_eq!(ecs_find_borrow!(world, entity_4, |_: &CompA| panic!()), false);
+
+    assert!(world.arch_foo.remove(entity_0).is_none());
+    assert!(world.arch_foo.remove(entity_1).is_none());
+    assert!(world.arch_foo.remove(entity_2).is_none());
+    assert!(world.arch_foo.remove(entity_3).is_none());
+    assert!(world.arch_foo.remove(entity_4).is_none());
+
+    let entity_0b = world.arch_foo.push((CompA(1000),));
+    let entity_1b = world.arch_foo.push((CompA(1001),));
+    let entity_2b = world.arch_foo.push((CompA(1002),));
+    let entity_3b = world.arch_foo.push((CompA(1003),));
+    let entity_4b = world.arch_foo.push((CompA(1004),));
+
+    assert!(ecs_find!(world, entity_0b, |v: &CompA| assert_eq!(v.0, 1000)));
+    assert!(ecs_find!(world, entity_1b, |v: &CompA| assert_eq!(v.0, 1001)));
+    assert!(ecs_find!(world, entity_2b, |v: &CompA| assert_eq!(v.0, 1002)));
+    assert!(ecs_find!(world, entity_3b, |v: &CompA| assert_eq!(v.0, 1003)));
+    assert!(ecs_find!(world, entity_4b, |v: &CompA| assert_eq!(v.0, 1004)));
+
+    assert!(ecs_find_borrow!(world, entity_0b, |v: &CompA| assert_eq!(v.0, 1000)));
+    assert!(ecs_find_borrow!(world, entity_1b, |v: &CompA| assert_eq!(v.0, 1001)));
+    assert!(ecs_find_borrow!(world, entity_2b, |v: &CompA| assert_eq!(v.0, 1002)));
+    assert!(ecs_find_borrow!(world, entity_3b, |v: &CompA| assert_eq!(v.0, 1003)));
+    assert!(ecs_find_borrow!(world, entity_4b, |v: &CompA| assert_eq!(v.0, 1004)));
+}

--- a/tests/test_single_dyn.rs
+++ b/tests/test_single_dyn.rs
@@ -1,12 +1,14 @@
 use gecs::prelude::*;
 
 pub struct CompA(pub u32);
+pub struct CompZ; // ZST
 
 ecs_world! {
     ecs_archetype!(
         ArchFoo,
         dyn,
         CompA,
+        CompZ,
     );
 }
 
@@ -15,11 +17,39 @@ ecs_world! {
 pub fn test_single_dyn_push() {
     let mut world = World::default();
 
-    world.arch_foo.push((CompA(0),));
-    world.arch_foo.push((CompA(1),));
-    world.arch_foo.push((CompA(2),));
-    world.arch_foo.push((CompA(3),));
-    world.arch_foo.push((CompA(4),));
+    world.arch_foo.push((CompA(0), CompZ,));
+    world.arch_foo.push((CompA(1), CompZ,));
+    world.arch_foo.push((CompA(2), CompZ,));
+    world.arch_foo.push((CompA(3), CompZ,));
+    world.arch_foo.push((CompA(4), CompZ,));
+
+    assert_eq!(world.arch_foo.len(), 5);
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_push_with_capacity_zero() {
+    let mut world = World::with_capacity(0);
+
+    world.arch_foo.push((CompA(0), CompZ,));
+    world.arch_foo.push((CompA(1), CompZ,));
+    world.arch_foo.push((CompA(2), CompZ,));
+    world.arch_foo.push((CompA(3), CompZ,));
+    world.arch_foo.push((CompA(4), CompZ,));
+
+    assert_eq!(world.arch_foo.len(), 5);
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_push_with_capacity_all() {
+    let mut world = World::with_capacity(5);
+
+    world.arch_foo.push((CompA(0), CompZ,));
+    world.arch_foo.push((CompA(1), CompZ,));
+    world.arch_foo.push((CompA(2), CompZ,));
+    world.arch_foo.push((CompA(3), CompZ,));
+    world.arch_foo.push((CompA(4), CompZ,));
 
     assert_eq!(world.arch_foo.len(), 5);
 }
@@ -29,11 +59,11 @@ pub fn test_single_dyn_push() {
 pub fn test_single_dyn_entity() {
     let mut world = World::default();
 
-    let entity_0 = world.arch_foo.push((CompA(0),));
-    let entity_1 = world.arch_foo.push((CompA(1),));
-    let entity_2 = world.arch_foo.push((CompA(2),));
-    let entity_3 = world.arch_foo.push((CompA(3),));
-    let entity_4 = world.arch_foo.push((CompA(4),));
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     assert!(ecs_find!(world, entity_0, |v: &Entity<ArchFoo>| assert!(*v == entity_0)));
     assert!(ecs_find!(world, entity_1, |v: &Entity<ArchFoo>| assert!(*v == entity_1)));
@@ -53,11 +83,65 @@ pub fn test_single_dyn_entity() {
     assert!(world.arch_foo.remove(entity_3).is_some());
     assert!(world.arch_foo.remove(entity_4).is_some());
 
-    let entity_0b = world.arch_foo.push((CompA(0),));
-    let entity_1b = world.arch_foo.push((CompA(1),));
-    let entity_2b = world.arch_foo.push((CompA(2),));
-    let entity_3b = world.arch_foo.push((CompA(3),));
-    let entity_4b = world.arch_foo.push((CompA(4),));
+    let entity_0b = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1b = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2b = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3b = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4b = world.arch_foo.push((CompA(4), CompZ,));
+
+    assert!(entity_0 != entity_0b);
+    assert!(entity_1 != entity_1b);
+    assert!(entity_2 != entity_2b);
+    assert!(entity_3 != entity_3b);
+    assert!(entity_4 != entity_4b);
+
+    assert!(ecs_find!(world, entity_0b, |v: &Entity<ArchFoo>| assert!(*v == entity_0b)));
+    assert!(ecs_find!(world, entity_1b, |v: &Entity<ArchFoo>| assert!(*v == entity_1b)));
+    assert!(ecs_find!(world, entity_2b, |v: &Entity<ArchFoo>| assert!(*v == entity_2b)));
+    assert!(ecs_find!(world, entity_3b, |v: &Entity<ArchFoo>| assert!(*v == entity_3b)));
+    assert!(ecs_find!(world, entity_4b, |v: &Entity<ArchFoo>| assert!(*v == entity_4b)));
+
+    assert!(ecs_find_borrow!(world, entity_0b, |v: &Entity<ArchFoo>| assert!(*v == entity_0b)));
+    assert!(ecs_find_borrow!(world, entity_1b, |v: &Entity<ArchFoo>| assert!(*v == entity_1b)));
+    assert!(ecs_find_borrow!(world, entity_2b, |v: &Entity<ArchFoo>| assert!(*v == entity_2b)));
+    assert!(ecs_find_borrow!(world, entity_3b, |v: &Entity<ArchFoo>| assert!(*v == entity_3b)));
+    assert!(ecs_find_borrow!(world, entity_4b, |v: &Entity<ArchFoo>| assert!(*v == entity_4b)));
+}
+
+#[test]
+#[rustfmt::skip]
+pub fn test_single_dyn_entity_with_capacity() {
+    let mut world = World::with_capacity(5);
+
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
+
+    assert!(ecs_find!(world, entity_0, |v: &Entity<ArchFoo>| assert!(*v == entity_0)));
+    assert!(ecs_find!(world, entity_1, |v: &Entity<ArchFoo>| assert!(*v == entity_1)));
+    assert!(ecs_find!(world, entity_2, |v: &Entity<ArchFoo>| assert!(*v == entity_2)));
+    assert!(ecs_find!(world, entity_3, |v: &Entity<ArchFoo>| assert!(*v == entity_3)));
+    assert!(ecs_find!(world, entity_4, |v: &Entity<ArchFoo>| assert!(*v == entity_4)));
+
+    assert!(ecs_find_borrow!(world, entity_0, |v: &Entity<ArchFoo>| assert!(*v == entity_0)));
+    assert!(ecs_find_borrow!(world, entity_1, |v: &Entity<ArchFoo>| assert!(*v == entity_1)));
+    assert!(ecs_find_borrow!(world, entity_2, |v: &Entity<ArchFoo>| assert!(*v == entity_2)));
+    assert!(ecs_find_borrow!(world, entity_3, |v: &Entity<ArchFoo>| assert!(*v == entity_3)));
+    assert!(ecs_find_borrow!(world, entity_4, |v: &Entity<ArchFoo>| assert!(*v == entity_4)));
+
+    assert!(world.arch_foo.remove(entity_0).is_some());
+    assert!(world.arch_foo.remove(entity_1).is_some());
+    assert!(world.arch_foo.remove(entity_2).is_some());
+    assert!(world.arch_foo.remove(entity_3).is_some());
+    assert!(world.arch_foo.remove(entity_4).is_some());
+
+    let entity_0b = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1b = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2b = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3b = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4b = world.arch_foo.push((CompA(4), CompZ,));
 
     assert!(entity_0 != entity_0b);
     assert!(entity_1 != entity_1b);
@@ -83,11 +167,11 @@ pub fn test_single_dyn_entity() {
 pub fn test_single_dyn_find() {
     let mut world = World::default();
 
-    let entity_0 = world.arch_foo.push((CompA(0),));
-    let entity_1 = world.arch_foo.push((CompA(1),));
-    let entity_2 = world.arch_foo.push((CompA(2),));
-    let entity_3 = world.arch_foo.push((CompA(3),));
-    let entity_4 = world.arch_foo.push((CompA(4),));
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     assert!(ecs_find!(world, entity_0, |v: &CompA| assert_eq!(v.0, 0)));
     assert!(ecs_find!(world, entity_1, |v: &CompA| assert_eq!(v.0, 1)));
@@ -147,11 +231,11 @@ pub fn test_single_dyn_find() {
 pub fn test_single_dyn_iter() {
     let mut world = World::default();
 
-    let _entity_0 = world.arch_foo.push((CompA(0),));
-    let _entity_1 = world.arch_foo.push((CompA(1),));
-    let _entity_2 = world.arch_foo.push((CompA(2),));
-    let _entity_3 = world.arch_foo.push((CompA(3),));
-    let _entity_4 = world.arch_foo.push((CompA(4),));
+    let _entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let _entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let _entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let _entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let _entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     let mut sum = 0;
     ecs_iter!(world, |v: &CompA| sum += v.0);
@@ -193,11 +277,11 @@ pub fn test_single_dyn_iter() {
 pub fn test_single_dyn_iter_write() {
     let mut world = World::default();
 
-    let _entity_0 = world.arch_foo.push((CompA(0),));
-    let _entity_1 = world.arch_foo.push((CompA(1),));
-    let _entity_2 = world.arch_foo.push((CompA(2),));
-    let _entity_3 = world.arch_foo.push((CompA(3),));
-    let _entity_4 = world.arch_foo.push((CompA(4),));
+    let _entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let _entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let _entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let _entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let _entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     ecs_iter!(world, |v: &mut CompA| v.0 += 100);
 
@@ -241,11 +325,11 @@ pub fn test_single_dyn_iter_write() {
 pub fn test_single_dyn_remove_replace() {
     let mut world = World::default();
 
-    let entity_0 = world.arch_foo.push((CompA(0),));
-    let entity_1 = world.arch_foo.push((CompA(1),));
-    let entity_2 = world.arch_foo.push((CompA(2),));
-    let entity_3 = world.arch_foo.push((CompA(3),));
-    let entity_4 = world.arch_foo.push((CompA(4),));
+    let entity_0 = world.arch_foo.push((CompA(0), CompZ,));
+    let entity_1 = world.arch_foo.push((CompA(1), CompZ,));
+    let entity_2 = world.arch_foo.push((CompA(2), CompZ,));
+    let entity_3 = world.arch_foo.push((CompA(3), CompZ,));
+    let entity_4 = world.arch_foo.push((CompA(4), CompZ,));
 
     assert_eq!(world.arch_foo.len(), 5);
 
@@ -282,11 +366,11 @@ pub fn test_single_dyn_remove_replace() {
     assert!(world.arch_foo.remove(entity_3).is_none());
     assert!(world.arch_foo.remove(entity_4).is_none());
 
-    let entity_0b = world.arch_foo.push((CompA(1000),));
-    let entity_1b = world.arch_foo.push((CompA(1001),));
-    let entity_2b = world.arch_foo.push((CompA(1002),));
-    let entity_3b = world.arch_foo.push((CompA(1003),));
-    let entity_4b = world.arch_foo.push((CompA(1004),));
+    let entity_0b = world.arch_foo.push((CompA(1000), CompZ,));
+    let entity_1b = world.arch_foo.push((CompA(1001), CompZ,));
+    let entity_2b = world.arch_foo.push((CompA(1002), CompZ,));
+    let entity_3b = world.arch_foo.push((CompA(1003), CompZ,));
+    let entity_4b = world.arch_foo.push((CompA(1004), CompZ,));
 
     assert!(ecs_find!(world, entity_0b, |v: &CompA| assert_eq!(v.0, 1000)));
     assert!(ecs_find!(world, entity_1b, |v: &CompA| assert_eq!(v.0, 1001)));


### PR DESCRIPTION
Adding support for dynamic archetypes by specifying `dyn` as the archetype capacity in `ecs_archetype!`.